### PR TITLE
Remove setup.sh from CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,3 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-
-      - name: Initialize environment
-        run: ./setup.sh
-
-

--- a/.github/workflows/clone-templates.yml
+++ b/.github/workflows/clone-templates.yml
@@ -29,8 +29,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run setup
-        run: ./setup.sh
 
       - name: Commit changes
         run: |

--- a/.github/workflows/clone-vendors.yml
+++ b/.github/workflows/clone-vendors.yml
@@ -30,8 +30,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run setup
-        run: ./setup.sh
 
       - name: Commit changes
         run: |

--- a/.github/workflows/update-vendor.yml
+++ b/.github/workflows/update-vendor.yml
@@ -34,8 +34,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run setup script
-        run: ./setup.sh
 
       - name: Commit changes
         run: |

--- a/DEV_INSTRUCTIONS.md
+++ b/DEV_INSTRUCTIONS.md
@@ -12,7 +12,8 @@ This repository uses Codex for automated code generation. These guidelines tell 
 3. The *Update Vendor Apps* workflow clones all repositories from the merged
     lists and regenerates `codex.json`. Run `./setup.sh` locally for the same
     effect (requires `jq`).
-4. The CI workflow executes the same script on every push.
+4. The CI workflow only installs dependencies and runs tests. It no longer
+   runs `./setup.sh` automatically.
 5. Example payloads or external API docs belong in `sample_data/`.
 
 ## Repository Layout

--- a/instructions/README.md
+++ b/instructions/README.md
@@ -10,7 +10,8 @@ automation guidelines used by Codex see `../DEV_INSTRUCTIONS.md`.
 3. The *Update Vendor Apps* workflow clones all repositories, merges any
    `vendor-repos.txt` from the templates and refreshes `codex.json`. Run
    `../setup.sh` locally if you want to perform the same steps manually.
-4. The `CI` workflow executes the same script on every push.
+4. The `CI` workflow only installs dependencies and runs tests. It no longer
+   executes `../setup.sh` automatically.
 5. Store JSON example files and API docs in `../sample_data` when needed.
    The folder is indexed in `codex.json` automatically.
 


### PR DESCRIPTION
## Summary
- stop running `setup.sh` in all GitHub workflows
- update docs to reflect that CI no longer calls the script

## Testing
- `bash -n setup.sh`
- `yamllint .github/workflows/*.yml`

------
https://chatgpt.com/codex/tasks/task_b_6859a4b8aa54832a8244c628d0fb2dce