### PR TITLE
Add templates as git submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository acts as the base for building custom Frappe apps with **Codex**.
    - `custom_vendors.json`
    - `templates.txt`
    - `codex.json`
-   - `scripts/sync_templates.sh`
+   - `scripts/sync_templates.sh` – synchronises template repositories as Git submodules
 
 4. **Edit the configuration** files if needed:
    - `templates.txt` lists additional template repositories.
@@ -34,7 +34,7 @@ This repository acts as the base for building custom Frappe apps with **Codex**.
    - Place optional payloads under `sample_data/`.
    When you include templates, look at their `DEV_INSTRUCTIONS.md` files and
    combine those notes with this repository's instructions.
-5. **Fetch template repositories** if you added any URLs to `templates.txt`:
+5. **Synchronise template repositories as submodules** if you added any URLs to `templates.txt`:
    ```bash
    ./scripts/sync_templates.sh
 

--- a/scripts/sync_templates.sh
+++ b/scripts/sync_templates.sh
@@ -15,12 +15,14 @@ while IFS= read -r repo; do
     [ -z "$repo" ] && continue
     name="$(basename "$repo" .git)"
     target="$ROOT_DIR/$name"
-    if [ ! -d "$target/.git" ]; then
-        echo "📥 Cloning $repo into $target"
-        git clone "$repo" "$target"
+    if grep -q "path = $name" "$ROOT_DIR/.gitmodules" 2>/dev/null; then
+        echo "🔄 Updating submodule $target"
+        git submodule update --remote "$target"
+    elif [ -d "$target" ]; then
+        echo "⚠️ $target exists but is not a submodule. Skipping..."
     else
-        echo "🔄 Updating $target"
-        git -C "$target" pull --ff-only
+        echo "🔗 Adding $repo as submodule at $target"
+        git submodule add "$repo" "$target"
     fi
     if [ -d "$target/instructions" ]; then
         echo "Found instructions in $target"


### PR DESCRIPTION
## Summary
- update sync script so it adds template repositories as submodules
- document the submodule behaviour in the README

## Testing
- `bash -n scripts/sync_templates.sh`
- `./scripts/sync_templates.sh`

------
https://chatgpt.com/codex/tasks/task_b_6859ca856ea8832ab3f5aaa3d6b214e9