### PR TITLE
Fix create-app workflow push permissions

### DIFF
--- a/.github/workflows/create-app-repo.yml
+++ b/.github/workflows/create-app-repo.yml
@@ -7,6 +7,9 @@ on:
         description: 'Name of the new app'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   scaffold:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- enable `contents: write` permission for the create-app workflow so it can push changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6859f4b3d1a4832a81ff4de2225c238e