### PR TITLE
Fix publish workflow write permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ name: publish
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   clean:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow pushing the `published` branch in the publish workflow by granting write permissions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6859fc6469fc832a986cd170d5aaaf14