### PR TITLE
Fix submodule cleanup on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           rm -rf vendor template apps.json DEV_INSTRUCTIONS.md custom_vendors.json
+          git submodule deinit -f --all || true
+          rm -rf .git/modules
           find . -name '.git*' -not -name '.git' -exec rm -rf {} +
           git add -A
           git commit -m "chore: publish"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The following GitHub workflows orchestrate the environment after pushing:
 - **clone-vendors** – pulls vendor apps from each template `apps.json` and from `custom_vendors.json`. It generates a consolidated `apps.json` in your repo root.
 - **update-vendor** – refreshes vendor apps on a schedule or when configuration files change.
 - **create-app-repo** – scaffolds a new app without using Bench. It records the framework versions and requirements in a temporary README and deletes itself after completion so the workflow can only run once.
-- **publish** – prepares a clean `published` branch by removing development artifacts (`.git*`, `template*`, `vendor/`, `apps.json`, `DEV_INSTRUCTIONS.md`, `custom_vendors.json`). Use this branch to distribute the final app.
+- **publish** – prepares a clean `published` branch by removing development artifacts (`.git*`, `template*`, `vendor/`, `apps.json`, `DEV_INSTRUCTIONS.md`, `custom_vendors.json`) and all submodule metadata. Use this branch to distribute the final app.
 
 After the **publish** workflow you can clone the `published` branch to install the app in a standard Frappe environment.
 


### PR DESCRIPTION
## Summary
- remove submodule metadata when creating the `published` branch
- document that publish removes submodule data

## Testing
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_6859feba2cd0832aba81fde4f3231970