### PR TITLE
Improve publish workflow cleanup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           rm -rf vendor template apps.json DEV_INSTRUCTIONS.md custom_vendors.json
+          rm -rf frappe_app_template erpnext_app_template template_frappe template_erpnext || true
+          find . -maxdepth 1 -type d -name '*_app_template*' -exec rm -rf {} + || true
+          if [ -f .gitmodules ]; then
+            git config -f .gitmodules --get-regexp path | awk '{print $2}' | xargs -r rm -rf
+          fi
           git submodule deinit -f --all || true
           rm -rf .git/modules
           find . -name '.git*' -not -name '.git' -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The following GitHub workflows orchestrate the environment after pushing:
 - **clone-vendors** – pulls vendor apps from each template `apps.json` and from `custom_vendors.json`. It generates a consolidated `apps.json` in your repo root.
 - **update-vendor** – refreshes vendor apps on a schedule or when configuration files change.
 - **create-app-repo** – scaffolds a new app without using Bench. It records the framework versions and requirements in a temporary README and deletes itself after completion so the workflow can only run once.
-- **publish** – prepares a clean `published` branch by removing development artifacts (`.git*`, `template*`, `vendor/`, `apps.json`, `DEV_INSTRUCTIONS.md`, `custom_vendors.json`) and all submodule metadata. Use this branch to distribute the final app.
+- **publish** – prepares a clean `published` branch by removing development artifacts (`.git*`, `template*`, `vendor/`, `apps.json`, `DEV_INSTRUCTIONS.md`, `custom_vendors.json`) and all submodule metadata. The workflow removes any remaining template directories such as `frappe_app_template` or `erpnext_app_template` and deletes submodule folders listed in `.gitmodules` before purging the metadata. Use this branch to distribute the final app.
 
 After the **publish** workflow you can clone the `published` branch to install the app in a standard Frappe environment.
 


### PR DESCRIPTION
## Summary
- remove submodule directories from `.gitmodules` before deleting metadata
- document the extra cleanup step in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685a01448478832a839f1d7c64351ba0