### PR TITLE
Fix YAML indentation for create-app workflow

### DIFF
--- a/.github/workflows/create-app-repo.yml
+++ b/.github/workflows/create-app-repo.yml
@@ -32,13 +32,13 @@ jobs:
           echo "__version__ = '0.0.1'" > app/$APP/__init__.py
           echo "$APP" > app/$APP/modules.txt
           cat <<'EOF' > app/$APP/patches.txt
-[pre_model_sync]
-# Patches added in this section will be executed before doctypes are migrated
-# Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
+          [pre_model_sync]
+          # Patches added in this section will be executed before doctypes are migrated
+          # Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
 
-[post_model_sync]
-# Patches added in this section will be executed after doctypes are migrated
-EOF
+          [post_model_sync]
+          # Patches added in this section will be executed after doctypes are migrated
+          EOF
           touch app/$APP/config/__init__.py
           touch app/$APP/templates/__init__.py
           touch app/$APP/$APP/__init__.py


### PR DESCRIPTION
## Summary
- fix indentation in create-app-repo workflow so YAML is valid

## Testing
- `python - <<'PY'
import yaml
with open('.github/workflows/create-app-repo.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`

------
https://chatgpt.com/codex/tasks/task_b_685c9105005c832aa1e33ea8e9a28b52