### PR TITLE
Copy .gitignore to parent repo if missing

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -21,6 +21,9 @@ if [ -d "$PARENT_DIR/.git" ] && [ "$PARENT_DIR" != "$SCRIPT_DIR" ]; then
         cp -r "$SCRIPT_DIR/scripts" "$PARENT_DIR/"
         chmod +x "$PARENT_DIR"/scripts/*.sh
     fi
+    if [ "$PARENT_DIR" != "$SCRIPT_DIR" ] && [ ! -f "$PARENT_DIR/.gitignore" ] && [ -f "$SCRIPT_DIR/.gitignore" ]; then
+        cp "$SCRIPT_DIR/.gitignore" "$PARENT_DIR/.gitignore"
+    fi
     CONFIG_TARGET="$PARENT_DIR"
 else
     CONFIG_TARGET="$SCRIPT_DIR"


### PR DESCRIPTION
## Summary
- copy `.gitignore` to the parent repository when running `setup.sh` as a submodule

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685d5ce7f520832abd12aed7d26b5e7e