### PR TITLE
Fix .gitignore location for scaffolded apps

### DIFF
--- a/.github/workflows/create-app-repo.yml
+++ b/.github/workflows/create-app-repo.yml
@@ -181,7 +181,7 @@ jobs:
           EOF
 
           # Include default ignore rules
-          cp "${{ github.workspace }}/.gitignore" "app/$APP/.gitignore"
+          cp "${{ github.workspace }}/.gitignore" "app/.gitignore"
 
       - name: Commit app
         run: |


### PR DESCRIPTION
## Summary
- ensure the create-app-repo workflow copies the `.gitignore` to `/app`

## Testing
- `pre-commit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d642d0124832a81f7b21212ece7b2