### PR TITLE
Update vendors workflow triggers

### DIFF
--- a/.github/workflows/clone-vendors.yml
+++ b/.github/workflows/clone-vendors.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths:
       - custom_vendors.json
+      - templates.txt
+      - '**/apps.json'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- trigger vendor cloning when `custom_vendors.json`, `templates.txt` or any `apps.json` files change
- keep manual dispatch support

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685f3c60a89c832a83d232eb84aa435c