### PR TITLE
Add submodule execution guard

### DIFF
--- a/scripts/bootstrap_project.sh
+++ b/scripts/bootstrap_project.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+TEMPLATE_DIR="$ROOT_DIR/frappe_app_template"
+
+if [ ! -f "$TEMPLATE_DIR/setup.sh" ]; then
+  echo "❌ frappe_app_template submodule not found at $TEMPLATE_DIR" >&2
+  exit 1
+fi
+
+cp "$TEMPLATE_DIR/setup.sh" "$ROOT_DIR/setup.sh"
+chmod +x "$ROOT_DIR/setup.sh"
+
+pushd "$ROOT_DIR" >/dev/null
+./setup.sh
+popd >/dev/null
+
+rm -f "$ROOT_DIR/setup.sh"

--- a/scripts/clone_templates.sh
+++ b/scripts/clone_templates.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+# Prevent execution inside the frappe_app_template submodule
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ "$toplevel" == *"/frappe_app_template" ]]; then
+  echo "⛔ ERROR: You are inside the frappe_app_template submodule."
+  echo "💡 Please run this script from the root of your app repository, not from inside the template."
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 TEMPLATE_FILE="${TEMPLATE_FILE:-$ROOT_DIR/templates.txt}"

--- a/scripts/clone_vendors.sh
+++ b/scripts/clone_vendors.sh
@@ -2,6 +2,14 @@
 set -euo pipefail
 export GIT_TERMINAL_PROMPT=0
 
+# Prevent execution inside the frappe_app_template submodule
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ "$toplevel" == *"/frappe_app_template" ]]; then
+  echo "⛔ ERROR: You are inside the frappe_app_template submodule."
+  echo "💡 Please run this script from the root of your app repository, not from inside the template."
+  exit 1
+fi
+
 # Colors for output
 GREEN="\033[1;32m"
 YELLOW="\033[1;33m"

--- a/scripts/remove_template.sh
+++ b/scripts/remove_template.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+# Prevent execution inside the frappe_app_template submodule
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ "$toplevel" == *"/frappe_app_template" ]]; then
+  echo "⛔ ERROR: You are inside the frappe_app_template submodule."
+  echo "💡 Please run this script from the root of your app repository, not from inside the template."
+  exit 1
+fi
+
 if [ $# -ne 1 ]; then
     echo "Usage: $0 <template-name>" >&2
     exit 1

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# Prevent execution inside the frappe_app_template submodule
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ "$toplevel" == *"/frappe_app_template" ]]; then
+  echo "⛔ ERROR: You are inside the frappe_app_template submodule."
+  echo "💡 Please run this script from the root of your app repository, not from inside the template."
+  exit 1
+fi
+
 # Determine the script and parent directories
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PARENT_DIR="$(dirname "$SCRIPT_DIR")"


### PR DESCRIPTION
## Summary
- add guard in `setup.sh`
- add same guard in vendor management scripts
- create `bootstrap_project.sh` helper

## Testing
- `./setup.sh`
- `pytest -q` *(fails: CalledProcessError)*

------
https://chatgpt.com/codex/tasks/task_b_685f61e43604832a91a4e59cec535f1c