### PR TITLE
Fix vendor cleanup script

### DIFF
--- a/scripts/clone_templates.sh
+++ b/scripts/clone_templates.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Prevent execution inside the frappe_app_template submodule
-toplevel=$(git rev-parse --show-toplevel 2>/dev/null)
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null || true)
 if [[ "$toplevel" == *"/frappe_app_template" ]]; then
   echo "⛔ ERROR: You are inside the frappe_app_template submodule."
   echo "💡 Please run this script from the root of your app repository, not from inside the template."

--- a/scripts/clone_vendors.sh
+++ b/scripts/clone_vendors.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 export GIT_TERMINAL_PROMPT=0
 
 # Prevent execution inside the frappe_app_template submodule
-toplevel=$(git rev-parse --show-toplevel 2>/dev/null)
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null || true)
 if [[ "$toplevel" == *"/frappe_app_template" ]]; then
   echo "⛔ ERROR: You are inside the frappe_app_template submodule."
   echo "💡 Please run this script from the root of your app repository, not from inside the template."
@@ -113,6 +113,8 @@ done
 # prune submodules not present in current config
 if [ -f "$ROOT_DIR/.gitmodules" ]; then
     while IFS= read -r path; do
+        # only manage submodules under vendor/
+        [[ "$path" == vendor/* ]] || continue
         app="$(basename "$path")"
         if [ -z "${REPOS[$app]+x}" ]; then
             echo -e "${YELLOW}🗑 Removing obsolete submodule $app${RESET}"

--- a/scripts/remove_template.sh
+++ b/scripts/remove_template.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Prevent execution inside the frappe_app_template submodule
-toplevel=$(git rev-parse --show-toplevel 2>/dev/null)
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null || true)
 if [[ "$toplevel" == *"/frappe_app_template" ]]; then
   echo "⛔ ERROR: You are inside the frappe_app_template submodule."
   echo "💡 Please run this script from the root of your app repository, not from inside the template."


### PR DESCRIPTION
## Summary
- ignore template submodule when pruning vendor submodules
- allow helper scripts to run outside git repos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f6aa29914832aa5452632e120dc06