### PR TITLE
Update default branch to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ develop ]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/init_new_app_repo.yml
+++ b/.github/workflows/init_new_app_repo.yml
@@ -2,7 +2,7 @@ name: init_new_app_repo
 
 on:
   push:
-    branches: [ main ]
+    branches: [ develop ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [develop]
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ codex.json          # Index of active templates (Codex references this)
 
 1. **Create your project repository**
    ```bash
-   git init my-app
+   git init -b develop my-app
    cd my-app
    ```
 
@@ -61,8 +61,12 @@ codex.json          # Index of active templates (Codex references this)
 
 7. **Push and initialize**
    ```bash
-   git push -u origin HEAD
+   git push -u origin develop
    ```
+
+   If no workflows start, verify that you pushed to **develop** and that
+   **Read and write** workflow permissions are enabled in the repository
+   settings.
 
    GitHub will trigger the following workflows:
    - `init_new_app_repo`

--- a/instructions/_core/prompts.md
+++ b/instructions/_core/prompts.md
@@ -96,3 +96,11 @@ Repos:
 ```
 
 Codex ergänzt `custom_vendors.json`, führt `setup.sh` erneut aus und holt die neuen Repositories nach `vendor/`.
+
+---
+
+## Prompt 10: GitHub Workflows prüfen
+
+"Nach dem ersten Push an GitHub sind `create-app-folder` und `publish` nicht gelaufen. Überprüfe, ob der Branch `develop` heißt und die Workflow-Rechte auf **Read and write** stehen."
+
+Codex stellt sicher, dass auf `develop` gepusht wurde und weist darauf hin, die Berechtigungen unter *Settings → Actions → General* zu aktivieren.


### PR DESCRIPTION
## Summary
- use `develop` in quick-start instructions
- adjust troubleshooting prompt to check the develop branch
- trigger CI workflows on the develop branch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685f739d3f7c832ab50a4264a93b2658