### PR TITLE
Fix workflow dispatch permissions

### DIFF
--- a/workflow_templates/clone-templates.yml
+++ b/workflow_templates/clone-templates.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   sync:

--- a/workflow_templates/clone-vendors.yml
+++ b/workflow_templates/clone-vendors.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   sync:

--- a/workflow_templates/init_new_app_repo.yml
+++ b/workflow_templates/init_new_app_repo.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   init:


### PR DESCRIPTION
## Summary
- allow trigger workflows to call other workflows by granting `actions: write` permission

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f7e934930832a8fbbb270b48257d5