### PR TITLE
Fix workflow loops and adjust dev requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,1 @@
 pytest
-shellcheck

--- a/workflow_templates/ci.yml
+++ b/workflow_templates/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/workflow_templates/clone-templates.yml
+++ b/workflow_templates/clone-templates.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   sync:
+    if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/workflow_templates/clone-vendors.yml
+++ b/workflow_templates/clone-vendors.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   sync:
+    if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/workflow_templates/test.yml
+++ b/workflow_templates/test.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test:
+    if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- avoid running CI jobs on pushes from the GitHub Actions bot
- skip push-triggered runs for clone templates and vendor workflows
- keep pytest as the only dev requirement

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest -q`
- `shellcheck scripts/*.sh`


------
https://chatgpt.com/codex/tasks/task_b_685f82921e60832aa1d9addaddbeb46f