### PR TITLE
Fix clone-vendors trigger in workflow

### DIFF
--- a/instructions/_core/DEV_GUIDE.md
+++ b/instructions/_core/DEV_GUIDE.md
@@ -23,3 +23,4 @@ Refer to the following guides for framework-specific tips:
 - [Frappe Notes](./frappe.md)
 - [ERPNext Notes](./erpnext.md)
 - [Using the Template as a Submodule](./submodule_usage.md)
+- [Repository Management Notes](./repo_mgmt.md)

--- a/instructions/_core/repo_mgmt.md
+++ b/instructions/_core/repo_mgmt.md
@@ -1,0 +1,18 @@
+# Repository Management Notes
+
+Use GitHub Actions API calls to trigger dependent workflows instead of relying on `gh workflow run`.
+This avoids interactive CLI issues in CI environments.
+
+Example: trigger `clone-vendors.yml` from another workflow.
+
+```yaml
+- name: Trigger clone-vendors via API
+  run: |
+    curl -X POST \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+      https://api.github.com/repos/${{ github.repository }}/actions/workflows/clone-vendors.yml/dispatches \
+      -d '{"ref":"${{ github.ref_name }}"}'
+```
+
+Update existing workflows accordingly so that nested workflows start reliably on GitHub.

--- a/workflow_templates/clone-templates.yml
+++ b/workflow_templates/clone-templates.yml
@@ -49,10 +49,11 @@ jobs:
             git push
           fi
 
-      - name: Trigger clone-vendors
+      - name: Trigger clone-vendors via API
         if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run clone-vendors.yml --ref "${GITHUB_REF}"
-          gh run watch
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/clone-vendors.yml/dispatches \
+            -d '{"ref":"${{ github.ref_name }}"}'

--- a/workflow_templates/init_new_app_repo.yml
+++ b/workflow_templates/init_new_app_repo.yml
@@ -21,7 +21,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run clone-templates.yml --ref "${GITHUB_REF}"
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/clone-templates.yml/dispatches \
+            -d '{"ref":"${{ github.ref_name }}"}'
           RUN_ID=$(gh run list --workflow clone-templates.yml --branch "${GITHUB_REF_NAME}" -L 1 --json databaseId -q '.[0].databaseId')
           gh run watch "$RUN_ID"
           gh run view "$RUN_ID" --exit-status
@@ -30,7 +34,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APP_NAME: ${{ github.event.repository.name }}
         run: |
-          gh workflow run create-app-folder.yml --ref "${GITHUB_REF}" -f app-name="$APP_NAME"
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/create-app-folder.yml/dispatches \
+            -d '{"ref":"${{ github.ref_name }}","inputs":{"app-name":"'$APP_NAME'"}}'
           RUN_ID=$(gh run list --workflow create-app-folder.yml --branch "${GITHUB_REF_NAME}" -L 1 --json databaseId -q '.[0].databaseId')
           gh run watch "$RUN_ID"
           gh run view "$RUN_ID" --exit-status
@@ -38,7 +46,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run publish.yml --ref "${GITHUB_REF}"
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/publish.yml/dispatches \
+            -d '{"ref":"${{ github.ref_name }}"}'
           RUN_ID=$(gh run list --workflow publish.yml --branch "${GITHUB_REF_NAME}" -L 1 --json databaseId -q '.[0].databaseId')
           gh run watch "$RUN_ID"
           gh run view "$RUN_ID" --exit-status


### PR DESCRIPTION
## Summary
- call the GitHub Actions API to trigger `clone-vendors.yml`
- update `init_new_app_repo` workflow to use the same API call style
- add repository management docs about API-based workflow triggers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685f8f5aee20832ab79ff5162c59b09d