### PR TITLE
Fix init workflow push conflicts

### DIFF
--- a/workflow_templates/init_new_app_repo.yml
+++ b/workflow_templates/init_new_app_repo.yml
@@ -76,5 +76,6 @@ jobs:
           git rm .github/workflows/init_new_app_repo.yml 2>/dev/null || true
           if ! git diff --cached --quiet; then
             git commit -m "chore: remove init_new_app_repo workflow"
+            git pull --rebase origin "${GITHUB_REF_NAME}"
             git push
           fi


### PR DESCRIPTION
## Summary
- prevent push conflicts in `init_new_app_repo.yml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f9dd6e9c0832aa250cc0f2e9298f3