### PR TITLE
Fix init workflow push conflicts

### DIFF
--- a/workflow_templates/clone-templates.yml
+++ b/workflow_templates/clone-templates.yml
@@ -49,11 +49,21 @@ jobs:
             git push
           fi
 
-      - name: Trigger clone-vendors via API
+      - name: Trigger clone-vendors via API and wait
         if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer $GH_TOKEN" \
             https://api.github.com/repos/${{ github.repository }}/actions/workflows/clone-vendors.yml/dispatches \
             -d '{"ref":"${{ github.ref_name }}"}'
+          RUN_ID=""
+          echo "Waiting for clone-vendors run to start..."
+          until [ -n "$RUN_ID" ]; do
+            sleep 5
+            RUN_ID=$(gh run list --workflow clone-vendors.yml --branch "${GITHUB_REF_NAME}" --json databaseId,status -q 'map(select(.status=="queued" or .status=="in_progress"))[0].databaseId')
+          done
+          gh run watch "$RUN_ID"
+          gh run view "$RUN_ID" --exit-status

--- a/workflow_templates/init_new_app_repo.yml
+++ b/workflow_templates/init_new_app_repo.yml
@@ -76,5 +76,6 @@ jobs:
           git rm .github/workflows/init_new_app_repo.yml 2>/dev/null || true
           if ! git diff --cached --quiet; then
             git commit -m "chore: remove init_new_app_repo workflow"
+            git pull --rebase origin "${GITHUB_REF_NAME}"
             git push
           fi


### PR DESCRIPTION
## Summary
- prevent push conflicts in `init_new_app_repo.yml`
- wait for `clone-vendors` to finish in `clone-templates.yml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f9dd6e9c0832aa250cc0f2e9298f3