### PR TITLE
Fix test workflow submodule checkout

### DIFF
--- a/workflow_templates/test.yml
+++ b/workflow_templates/test.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Summary
- ensure the test workflow checks out submodules so pytest can discover the test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685fa4d8be04832aa87829f031c7ebee