### PR TITLE
Align workflow polling intervals

### DIFF
--- a/workflow_templates/init_new_app_repo.yml
+++ b/workflow_templates/init_new_app_repo.yml
@@ -32,7 +32,7 @@ jobs:
             sleep 5
             RUN_ID=$(gh run list --workflow update-templates.yml --branch "${GITHUB_REF_NAME}" --json databaseId,status -q 'map(select(.status=="queued" or .status=="in_progress"))[0].databaseId')
           done
-          gh run watch "$RUN_ID"
+          gh run watch "$RUN_ID" --interval 30
           gh run view "$RUN_ID" --exit-status
       - name: Trigger and await create-app-folder
         env:
@@ -50,7 +50,7 @@ jobs:
             sleep 5
             RUN_ID=$(gh run list --workflow create-app-folder.yml --branch "${GITHUB_REF_NAME}" --json databaseId,status -q 'map(select(.status=="queued" or .status=="in_progress"))[0].databaseId')
           done
-          gh run watch "$RUN_ID"
+          gh run watch "$RUN_ID" --interval 30
           gh run view "$RUN_ID" --exit-status
       - name: Trigger and await publish
         env:
@@ -67,7 +67,7 @@ jobs:
             sleep 5
             RUN_ID=$(gh run list --workflow publish.yml --branch "${GITHUB_REF_NAME}" --json databaseId,status -q 'map(select(.status=="queued" or .status=="in_progress"))[0].databaseId')
           done
-          gh run watch "$RUN_ID"
+          gh run watch "$RUN_ID" --interval 30
           gh run view "$RUN_ID" --exit-status
       - name: Remove workflow
         run: |


### PR DESCRIPTION
## Summary
- standardize GH log polling to 30 seconds in `init_new_app_repo.yml`

No `context.json` file exists in the repository so no removal was required.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685faa2d6c98832abc478054197d3c13