### PR TITLE
Fix update-vendors trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,14 @@ codex.json          # Index of active templates (Codex references this)
    **Read and write** workflow permissions are enabled in the repository
    settings.
 
-   GitHub will trigger the following workflows:
-   - `init_new_app_repo`
-   - `update-templates` *(automatically triggers `update-vendors`)*
-   - `create-app-folder`
-   - `publish`
+  GitHub will trigger the following workflows:
+  - `init_new_app_repo`
+  - `update-templates` *(automatically triggers `update-vendors` and waits for it to finish)*
+  - `create-app-folder`
+  - `publish`
+
+  The `update-vendors` workflow otherwise runs only when `custom_vendors.json` or
+  an `apps.json` file changes.
 
 ---
 

--- a/workflow_templates/update-vendors.yml
+++ b/workflow_templates/update-vendors.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths:
       - custom_vendors.json
-      - templates.txt
       - '**/apps.json'
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- only trigger `update-vendors` on `custom_vendors.json` or `apps.json`
- document new behaviour in README

## Testing
- `pip install -r requirements-dev.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_685fb47fa6b4832aadea09f9cc4f09a3