### PR TITLE
Fix brace expansion in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -141,7 +141,7 @@ fi
 # Create app skeleton if missing
 APP_DIR="$CONFIG_TARGET/app/$APP_NAME"
 if [ ! -d "$APP_DIR" ]; then
-    mkdir -p "$APP_DIR/{config,templates,$APP_NAME}"
+    mkdir -p "$APP_DIR"/{config,templates,"$APP_NAME"}
     echo "__version__ = '0.0.1'" > "$APP_DIR/__init__.py"
     echo "$APP_NAME" > "$APP_DIR/modules.txt"
     cat > "$APP_DIR/hooks.py" <<EOF


### PR DESCRIPTION
## Summary
- ensure `setup.sh` creates `config`, `templates` and app module directories separately
- all tests pass

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861d7119fc4832aa5d53e5f207df646