### PR TITLE
Improve setup and vendor update scripts

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -97,7 +97,7 @@ fi
 
 # Create example configuration files if missing
 if [ ! -f "$CONFIG_TARGET/vendors.txt" ]; then
-    echo "example_app" > "$CONFIG_TARGET/vendors.txt"
+    cp "$SCRIPT_DIR/vendors.txt" "$CONFIG_TARGET/vendors.txt"
 fi
 
 if [ ! -f "$CONFIG_TARGET/vendor_profiles/examples/example_app.json" ]; then


### PR DESCRIPTION
## Summary
- copy example `vendors.txt` during setup
- ensure `update_vendors.sh` checks and optionally repairs template submodule
- keep operations working even when HTTPS cloning is disabled

## Testing
- `pip install -r requirements-dev.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6861da2200b4832a9d50d42a11f0135a