### PR TITLE
Add framework vendor profiles

### DIFF
--- a/DEV_INSTRUCTIONS.md
+++ b/DEV_INSTRUCTIONS.md
@@ -26,6 +26,7 @@ This repository uses Codex for automated code generation. These guidelines tell 
 - `sample_data/` – reference payloads and docs.
 - `vendors.txt` – active vendor slugs.
 - `vendor_profiles/` – library of vendor profile JSON files.
+- `framework/` under `vendor_profiles/` stores core framework profiles like Frappe and Bench.
 - `apps.json` – default vendor apps and their versions.
 
 ## Additional Guidelines

--- a/apps.json
+++ b/apps.json
@@ -1,10 +1,10 @@
 {
   "bench": {
     "repo": "https://github.com/frappe/bench",
-    "branch": "v5.2.1"
+    "branch": "main"
   },
   "frappe": {
     "repo": "https://github.com/frappe/frappe",
-    "branch": "v13.3.0"
+    "branch": "version-15"
   }
 }

--- a/vendor_profiles/framework/bench.json
+++ b/vendor_profiles/framework/bench.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://github.com/frappe/bench",
+  "branch": "main"
+}

--- a/vendor_profiles/framework/frappe.json
+++ b/vendor_profiles/framework/frappe.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://github.com/frappe/frappe",
+  "branch": "version-15"
+}


### PR DESCRIPTION
## Summary
- create `framework` vendor category for core libraries
- add Frappe and Bench profiles
- update `apps.json` to use the same branches
- document new category in developer instructions

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861dfdde7d4832abf60f6b183b19c03