### PR TITLE
Remove submodule execution guards

### DIFF
--- a/instructions/_core/submodule_usage.md
+++ b/instructions/_core/submodule_usage.md
@@ -2,6 +2,10 @@
 
 This guide explains how to start a new repository that keeps the `frappe_app_template` as a Git submodule. The approach allows you to pull in updates from the template at any time.
 
+The helper scripts in `scripts/` now work both when the template is added as a
+submodule and when it is used standalone. They no longer abort if executed from
+within the template repository itself.
+
 ## 1. Repository Setup
 
 ```bash

--- a/scripts/bootstrap_project.sh
+++ b/scripts/bootstrap_project.sh
@@ -5,9 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 TEMPLATE_DIR="$ROOT_DIR/frappe_app_template"
 
+# Allow running inside the template repository by falling back to ROOT_DIR
 if [ ! -f "$TEMPLATE_DIR/setup.sh" ]; then
-  echo "❌ frappe_app_template submodule not found at $TEMPLATE_DIR" >&2
-  exit 1
+  TEMPLATE_DIR="$ROOT_DIR"
 fi
 
 cp "$TEMPLATE_DIR/setup.sh" "$ROOT_DIR/setup.sh"

--- a/scripts/clone_templates.sh
+++ b/scripts/clone_templates.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# Prevent execution inside the frappe_app_template submodule
-toplevel=$(git rev-parse --show-toplevel 2>/dev/null || true)
-if [[ "$toplevel" == *"/frappe_app_template" ]]; then
-  echo "⛔ ERROR: You are inside the frappe_app_template submodule."
-  echo "💡 Please run this script from the root of your app repository, not from inside the template."
-  exit 1
-fi
+# Previously this script refused to run inside the template repository.
+# It now works in both standalone and submodule contexts.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"

--- a/scripts/remove_template.sh
+++ b/scripts/remove_template.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# Prevent execution inside the frappe_app_template submodule
-toplevel=$(git rev-parse --show-toplevel 2>/dev/null || true)
-if [[ "$toplevel" == *"/frappe_app_template" ]]; then
-  echo "⛔ ERROR: You are inside the frappe_app_template submodule."
-  echo "💡 Please run this script from the root of your app repository, not from inside the template."
-  exit 1
-fi
+# This script can run both from a standalone template repository and from
+# projects that include the template as a submodule.
 
 if [ $# -ne 1 ]; then
     echo "Usage: $0 <template-name>" >&2

--- a/scripts/update_vendors.sh
+++ b/scripts/update_vendors.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 export GIT_TERMINAL_PROMPT=0
 
-# Prevent execution inside the template submodule
+# Detect whether we are running from the template repository itself
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-if [[ "$repo_root" == *"/frappe_app_template" ]]; then
-  echo "⛔ ERROR: Run this script from your app repository, not inside the template." >&2
-  exit 1
+in_template_repo=false
+if [[ "$(basename "$repo_root")" == "frappe_app_template" ]]; then
+  in_template_repo=true
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -51,7 +51,9 @@ check_template() {
   fi
 }
 
-check_template
+if [ "$in_template_repo" = false ]; then
+  check_template
+fi
 
 # read vendors list
 readarray -t RAW_LINES < <(grep -v '^#' "$VENDORS_FILE" 2>/dev/null | sed '/^\s*$/d')


### PR DESCRIPTION
## Summary
- allow running helper scripts directly in the template repo
- relax submodule requirement in `bootstrap_project.sh`
- document that scripts work standalone

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861e0008198832aa0d94e63a42e23e8