### PR TITLE
Add vendor_profiles fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ vendor_profiles/erp_business/erpnext.json
 Diese Profile werden beim Einrichten neuer Repositories genutzt, um die passenden Submodule zu klonen.
 Beim ersten Ausführen von `setup.sh` wird zudem automatisch eine leere `.gitmodules`-Datei erzeugt (bzw. `git submodule init` ausgeführt), falls diese noch nicht existiert.
 
-Frappe und Bench sind bereits in `apps.json` hinterlegt und werden bei jeder Ausführung von `update_vendors.sh` automatisch aktualisiert. Weitere Apps fügst du über `vendors.txt` hinzu. Dort kannst du entweder nur einen Slug eintragen – dann greift die passende Datei unter `vendor_profiles/` – oder ein eigenes Repository inklusive Branch. Zusätzlich kannst du beliebige Repositories direkt in `apps.json` oder `custom_vendors.json` angeben; diese werden beim nächsten `update_vendors.sh` berücksichtigt:
+Frappe und Bench sind bereits in `apps.json` hinterlegt und werden bei jeder Ausführung von `update_vendors.sh` automatisch aktualisiert. Weitere Apps fügst du über `vendors.txt` hinzu. Dort kannst du entweder nur einen Slug eintragen – dann greift die passende Datei unter `vendor_profiles/` (oder im Template‑Unterordner `frappe_app_template/vendor_profiles/`, falls kein lokaler Ordner vorhanden) – oder ein eigenes Repository inklusive Branch. Zusätzlich kannst du beliebige Repositories direkt in `apps.json` oder `custom_vendors.json` angeben; diese werden beim nächsten `update_vendors.sh` berücksichtigt:
 
 ```text
 # slug aus vendor_profiles
@@ -108,7 +108,7 @@ erpnext
 myaddon|https://github.com/me/myaddon|develop
 ```
 
-Passe bei Bedarf die JSON-Dateien unter `vendor_profiles/` an und starte danach `./scripts/update_vendors.sh` oder den Workflow **update-vendors**.
+Passe bei Bedarf die JSON-Dateien unter `vendor_profiles/` an und starte danach `./scripts/update_vendors.sh` oder den Workflow **update-vendors**. Existiert kein solcher Ordner, nutzt das Skript automatisch die Profile aus dem Template‑Verzeichnis.
 ## 🔁 Wissen aus App-Repos zurückführen
 
 App-Repos können neue Erkenntnisse lokal ablegen:

--- a/instructions/_core/DEV_GUIDE.md
+++ b/instructions/_core/DEV_GUIDE.md
@@ -5,8 +5,10 @@ automation guidelines used by Codex see `../DEV_INSTRUCTIONS.md`.
 
 1. Default versions for Frappe and Bench reside in `../apps.json`.
 2. List active vendor slugs in `../vendors.txt`. Passende Profil-Dateien liegen
-   unter `../vendor_profiles/<kategorie>/<slug>.json`. Du kannst auch eigene
-   Repositories direkt in `../apps.json` oder `../custom_vendors.json` hinterlegen.
+   unter `../vendor_profiles/<kategorie>/<slug>.json` oder im Template-Pfad
+   `../frappe_app_template/vendor_profiles/<kategorie>/<slug>.json`. Du kannst
+   auch eigene Repositories direkt in `../apps.json` oder `../custom_vendors.json`
+   hinterlegen.
 3. The *update-vendors* workflow clones all listed repositories and refreshes
    `apps.json`. Run
    `../setup.sh` locally if you want to perform the same steps manually.

--- a/instructions/_core/erpnext.md
+++ b/instructions/_core/erpnext.md
@@ -9,5 +9,6 @@
 * Für tiefergehende Anpassungen siehe die ERPNext-Dokumentation.
 
 Füge ERPNext als Vendor-Slug in `../vendors.txt` hinzu. Die nötige URL steht in
-`../vendor_profiles/erp_business/erpnext.json`. Anschließend synchronisiert
-*update-vendors* das Submodul automatisch.
+`../vendor_profiles/erp_business/erpnext.json` oder im Template-Verzeichnis
+`../frappe_app_template/vendor_profiles/erp_business/erpnext.json`.
+Anschließend synchronisiert *update-vendors* das Submodul automatisch.

--- a/instructions/_core/frappe.md
+++ b/instructions/_core/frappe.md
@@ -10,7 +10,8 @@
 
 Frappe und Bench werden über `../apps.json` verwaltet. Um zusätzliche Apps
 einzubinden, trage ihren Slug in `../vendors.txt` ein. Die Zuordnung zu Git-URL
-und Branch erfolgt über passende JSON-Dateien unter `../vendor_profiles/`.
+und Branch erfolgt über passende JSON-Dateien unter `../vendor_profiles/` oder
+im Template-Verzeichnis `../frappe_app_template/vendor_profiles/`.
 Alternativ kannst du ein Repository direkt in `../apps.json` hinterlegen, um es
 beim nächsten Lauf von **update-vendors** einzubinden. Oder trage es in
 `../custom_vendors.json` ein. Starte anschließend **update-vendors** oder führe

--- a/instructions/_core/submodule_usage.md
+++ b/instructions/_core/submodule_usage.md
@@ -18,8 +18,9 @@ Copy the configuration files from the template so you can adjust them:
 cp template/apps.json .
 cp template/custom_vendors.json .
 cp template/vendors.txt .
-cp -r template/vendor_profiles .
 ```
+
+`update_vendors.sh` falls back to `template/vendor_profiles/` when no `vendor_profiles/` directory exists in your project. Create the folder if you want to override or extend the provided profiles.
 
 Edit these files to add your desired vendor slugs and integration profiles.
 

--- a/scripts/update_vendors.sh
+++ b/scripts/update_vendors.sh
@@ -7,6 +7,15 @@ ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 VENDOR_DIR="$ROOT_DIR/vendor"
 VENDORS_FILE="${VENDORS_FILE:-$ROOT_DIR/vendors.txt}"
 PROFILES_DIR="${PROFILES_DIR:-$ROOT_DIR/vendor_profiles}"
+
+# fallback to template-provided profiles when none exist in the project
+if [ ! -d "$PROFILES_DIR" ]; then
+  if [ -d "$ROOT_DIR/frappe_app_template/vendor_profiles" ]; then
+    PROFILES_DIR="$ROOT_DIR/frappe_app_template/vendor_profiles"
+  elif [ -d "$ROOT_DIR/template/vendor_profiles" ]; then
+    PROFILES_DIR="$ROOT_DIR/template/vendor_profiles"
+  fi
+fi
 CODEX_JSON="$ROOT_DIR/codex.json"
 
 mkdir -p "$VENDOR_DIR"


### PR DESCRIPTION
## Summary
- adjust README and docs for vendor profile fallback
- look for vendor profiles in template when missing

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861ee946790832ab3ecd2d3d60e81c3