### PR TITLE
Fix vendor script fallback and simplify setup

### DIFF
--- a/custom_vendors.json
+++ b/custom_vendors.json
@@ -1,6 +1,3 @@
 {
-  "example_app": {
-    "repo": "https://github.com/example/example_app",
-    "branch": "v1.0.0"
-  }
+  
 }

--- a/custom_vendors.json
+++ b/custom_vendors.json
@@ -1,3 +1,6 @@
 {
-  
+  "example_app": {
+    "repo": "https://github.com/example/example_app",
+    "branch": "v1.0.0"
+  }
 }

--- a/scripts/update_vendors.sh
+++ b/scripts/update_vendors.sh
@@ -72,6 +72,9 @@ for line in "${RAW_LINES[@]}"; do
   else
     slug="$part1"
     profile_file=$(find "$PROFILES_DIR" -name "$slug.json" -print -quit 2>/dev/null || true)
+    if [[ -z "$profile_file" && -d "$SCRIPT_DIR/../vendor_profiles" ]]; then
+      profile_file=$(find "$SCRIPT_DIR/../vendor_profiles" -name "$slug.json" -print -quit 2>/dev/null || true)
+    fi
     if [[ -n "$profile_file" ]]; then
       repo=$(jq -r '.url // empty' "$profile_file" 2>/dev/null)
       branch=$(jq -r '.branch // .tag // ""' "$profile_file" 2>/dev/null)
@@ -120,7 +123,7 @@ for slug in "${!REPOS[@]}"; do
     fi
     updated+=("$slug")
   else
-    if git submodule add "$repo" "$path"; then
+    if git submodule add -f "$repo" "$path"; then
       changes=true
       installed+=("$slug")
     else

--- a/setup.sh
+++ b/setup.sh
@@ -119,7 +119,6 @@ if [ ! -f "$CONFIG_TARGET/custom_vendors.json" ]; then
   }
 }
 JSON
-    echo '{}' > "$CONFIG_TARGET/custom_vendors.json"
 fi
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -111,25 +111,9 @@ if [ ! -f "$CONFIG_TARGET/apps.json" ]; then
 fi
 
 if [ ! -f "$CONFIG_TARGET/custom_vendors.json" ]; then
-    cat > "$CONFIG_TARGET/custom_vendors.json" <<'JSON'
-{
-  "example_app": {
-    "repo": "https://github.com/example/example_app",
-    "branch": "v1.0.0"
-  }
-}
-JSON
+    echo '{}' > "$CONFIG_TARGET/custom_vendors.json"
 fi
 
-if [ ! -f "$CONFIG_TARGET/vendor_profiles/examples/example_app.json" ]; then
-    mkdir -p "$CONFIG_TARGET/vendor_profiles/examples"
-    cat > "$CONFIG_TARGET/vendor_profiles/examples/example_app.json" <<'JSON'
-{
-  "url": "https://github.com/example/example_app",
-  "branch": "v1.0.0"
-}
-JSON
-fi
 
 if [ ! -f "$CONFIG_TARGET/codex.json" ]; then
     cat > "$CONFIG_TARGET/codex.json" <<'JSON'

--- a/setup.sh
+++ b/setup.sh
@@ -111,6 +111,14 @@ if [ ! -f "$CONFIG_TARGET/apps.json" ]; then
 fi
 
 if [ ! -f "$CONFIG_TARGET/custom_vendors.json" ]; then
+    cat > "$CONFIG_TARGET/custom_vendors.json" <<'JSON'
+{
+  "example_app": {
+    "repo": "https://github.com/example/example_app",
+    "branch": "v1.0.0"
+  }
+}
+JSON
     echo '{}' > "$CONFIG_TARGET/custom_vendors.json"
 fi
 


### PR DESCRIPTION
## Summary
- add fallback to search vendor profiles in submodule
- force submodule add in update script
- simplify setup by removing example files

## Testing
- `pip install -r requirements-dev.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6861f1ca3620832abdba80363ce891e9