### PR TITLE
Fix init_new_app_repo workflow

### DIFF
--- a/workflow_templates/init_new_app_repo.yml
+++ b/workflow_templates/init_new_app_repo.yml
@@ -21,20 +21,20 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: false
-      - name: Trigger and await update-templates
+      - name: Trigger and await update-vendors
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GH_TOKEN" \
-            https://api.github.com/repos/${{ github.repository }}/actions/workflows/update-templates.yml/dispatches \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/update-vendors.yml/dispatches \
             -d '{"ref":"${{ github.ref_name }}"}'
           RUN_ID=""
-          echo "Waiting for update-templates run to start..."
+          echo "Waiting for update-vendors run to start..."
           until [ -n "$RUN_ID" ]; do
             sleep 5
-            RUN_ID=$(gh run list --workflow update-templates.yml --branch "${GITHUB_REF_NAME}" --json databaseId,status -q 'map(select(.status=="queued" or .status=="in_progress"))[0].databaseId')
+            RUN_ID=$(gh run list --workflow update-vendors.yml --branch "${GITHUB_REF_NAME}" --json databaseId,status -q 'map(select(.status=="queued" or .status=="in_progress"))[0].databaseId')
           done
           gh run watch "$RUN_ID" --interval 30
           gh run view "$RUN_ID" --exit-status


### PR DESCRIPTION
## Summary
- fix workflow reference: call `update-vendors` instead of missing `update-templates`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861f5a5ed94832a896125ca46b3f322