### PR TITLE
Ensure apps.json entries are preserved

### DIFF
--- a/scripts/update_vendors.sh
+++ b/scripts/update_vendors.sh
@@ -91,6 +91,13 @@ for line in "${RAW_LINES[@]}"; do
       tag=$(jq -r '.tag // empty' "$profile_file" 2>/dev/null)
     fi
   fi
+
+  if [[ -n "${REPOS[$slug]:-}" ]]; then
+    # Keep existing configuration from apps.json
+    recognized+=("$slug")
+    continue
+  fi
+
   if [[ -n "$repo" ]]; then
     REPOS[$slug]="$repo"
     BRANCHES[$slug]="$branch"
@@ -99,9 +106,6 @@ for line in "${RAW_LINES[@]}"; do
     sanitized=${ref//\//_}
     path="vendor/${slug}${ref:+-$sanitized}"
     PATHS[$slug]="$path"
-    recognized+=("$slug")
-  elif [[ -n "${REPOS[$slug]:-}" ]]; then
-    # slug already defined in apps.json, reuse existing repo
     recognized+=("$slug")
   else
     echo "⚠️  Unknown vendor: $slug" >&2

--- a/tests/test_update_vendors.py
+++ b/tests/test_update_vendors.py
@@ -236,3 +236,40 @@ def test_update_vendors_supports_tag(tmp_path):
     assert "tagtest" in data
     assert data["tagtest"]["tag"] == "v1.0"
     assert (tmp_path / "vendor" / "tagtest-v1.0").exists()
+
+
+def test_update_vendors_preserves_existing_apps_json(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    scripts_dir = repo_root / "scripts"
+    tmp_scripts = tmp_path / "scripts"
+    tmp_scripts.mkdir()
+    (tmp_scripts / "update_vendors.sh").write_text((scripts_dir / "update_vendors.sh").read_text())
+
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True)
+
+    original_repo = tmp_path / "original_repo"
+    original_repo.mkdir()
+    subprocess.run(["git", "init"], cwd=original_repo, check=True)
+    (original_repo / "README.md").write_text("orig")
+    subprocess.run(["git", "add", "README.md"], cwd=original_repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=original_repo, check=True)
+
+    alt_repo = tmp_path / "alt_repo"
+    alt_repo.mkdir()
+    subprocess.run(["git", "init"], cwd=alt_repo, check=True)
+    (alt_repo / "README.md").write_text("alt")
+    subprocess.run(["git", "add", "README.md"], cwd=alt_repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=alt_repo, check=True)
+
+    (tmp_path / "apps.json").write_text(json.dumps({"demo": {"repo": str(original_repo), "branch": "main"}}))
+    (tmp_path / "vendors.txt").write_text("demo\n")
+    prof_dir = tmp_path / "vendor_profiles"
+    prof_dir.mkdir()
+    (prof_dir / "demo.json").write_text(json.dumps({"url": str(alt_repo), "branch": "v1"}))
+
+    env = {**os.environ, "GIT_ALLOW_PROTOCOL": "file"}
+    subprocess.run(["bash", str(tmp_scripts / "update_vendors.sh")], cwd=tmp_path, check=True, env=env)
+
+    data = json.loads((tmp_path / "apps.json").read_text())
+    assert data["demo"]["repo"] == str(original_repo)
+    assert data["demo"]["branch"] == "main"


### PR DESCRIPTION
## Summary
- avoid overriding entries from `apps.json` when running `update_vendors.sh`
- add regression test ensuring the existing repository and branch remain untouched

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68620bed70c8832aa701d01c77f5a835