### PR TITLE
Enable submodule checkout in vendor update workflow

### DIFF
--- a/workflow_templates/update-vendors.yml
+++ b/workflow_templates/update-vendors.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          submodules: false
+          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
## Summary
- checkout git submodules recursively in the `update-vendors` workflow

## Testing
- `pip install -r requirements-dev.txt`
- `pytest`
- `git push` *(fails: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_b_686227b52d6c832aaa4d2f709fccc753