### PR TITLE
Enhance codex indexing

### DIFF
--- a/.github/workflows/generate_codex_index.yml
+++ b/.github/workflows/generate_codex_index.yml
@@ -23,15 +23,32 @@ jobs:
         run: |
           python - <<'PY'
           import os, json
-          paths = []
-          for base in ['instructions', 'vendor', 'app']:
-              if os.path.isdir(base):
-                  for root, dirs, files in os.walk(base):
-                      for name in dirs+files:
-                          p = os.path.join(root, name)
-                          paths.append(p)
+
+          sources = []
+
+          scenarios = os.path.join('instructions', '_scenarios')
+          if os.path.isdir(scenarios):
+              for root, _, files in os.walk(scenarios):
+                  for name in sorted(files):
+                      sources.append(os.path.join(root, name))
+
+          if os.path.isdir('app'):
+              for root, dirs, _ in os.walk('app'):
+                  dirs.sort()
+                  sources.append(root.rstrip('/') + '/')
+
+          if os.path.isdir('vendor'):
+              for entry in sorted(os.listdir('vendor')):
+                  vend_path = os.path.join('vendor', entry)
+                  if os.path.isdir(vend_path):
+                      for root, dirs, _ in os.walk(vend_path):
+                          dirs.sort()
+                          sources.append(root.rstrip('/') + '/')
+
+          sources.extend(['instructions/', 'sample_data/'])
+
           with open('codex.json', 'w') as f:
-              json.dump({'paths': paths}, f)
+              json.dump({'sources': sources}, f)
           PY
 
       - name: Extract codex gitlog

--- a/scripts/update_vendors.sh
+++ b/scripts/update_vendors.sh
@@ -235,10 +235,32 @@ for slug in "${recognized[@]}"; do
 done
 jq -n "$jq_filter" > "$ROOT_DIR/apps.json"
 
-sources=("app/")
+sources=()
+
+# prepend scenario files if available
+if [ -d "instructions/_scenarios" ]; then
+  while IFS= read -r f; do
+    sources+=("$f")
+  done < <(find instructions/_scenarios -type f | sort)
+fi
+
+# include full depth of app directory
+if [ -d "app" ]; then
+  while IFS= read -r d; do
+    sources+=("${d}/")
+  done < <(find app -type d | sort)
+fi
+
+# include full depth of vendor directories
 for slug in "${recognized[@]}"; do
-  sources+=("${PATHS[$slug]}/")
- done
+  path="${PATHS[$slug]}"
+  if [ -d "$path" ]; then
+    while IFS= read -r d; do
+      sources+=("${d}/")
+    done < <(find "$path" -type d | sort)
+  fi
+done
+
 sources+=("instructions/" "sample_data/")
 existing_templates="[]"
 if [ -f "$CODEX_JSON" ]; then


### PR DESCRIPTION
## Summary
- walk scenario files and list them first in codex index
- include complete directory tree of app/ and vendor/*/
- test ordered sources list

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68624324e388832ab9e5eb09044c7705