### PR TITLE
Add codex context printer

### DIFF
--- a/instructions/how_to_prompt_codex.md
+++ b/instructions/how_to_prompt_codex.md
@@ -31,3 +31,13 @@ If Codex suggests wrong files or incomplete steps:
 - Check the docs in `instructions/_core/` to see if they already cover your topic.
 - Rerun `generate_codex_by_scenario.py` after updating scenarios or instructions.
 
+
+## 5. Inspecting the active Codex context
+
+Run `scripts/print_codex_context.py` to see which files are prioritised for a scenario and which prompt template it suggests:
+
+```bash
+python scripts/print_codex_context.py --scenario my-scenario
+```
+
+The script reads `codex.json` and the chosen markdown file under `instructions/_scenarios/`. It prints the referenced paths with their index positions and shows the suggested prompt template from the scenario file.

--- a/scripts/print_codex_context.py
+++ b/scripts/print_codex_context.py
@@ -1,0 +1,71 @@
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(
+        description="Print codex context and prompt for a scenario"
+    )
+    parser.add_argument(
+        "--scenario", required=True, help="Name of the scenario without extension"
+    )
+    return parser.parse_args(args)
+
+
+def load_sources():
+    with open("codex.json") as f:
+        data = json.load(f)
+    return data.get("sources", [])
+
+
+def parse_scenario_file(name):
+    path = Path("instructions") / "_scenarios" / f"{name}.md"
+    if not path.is_file():
+        raise FileNotFoundError(f"Scenario file not found: {path}")
+    content = path.read_text().splitlines()
+
+    prompt = None
+    references = []
+    in_refs = False
+    for i, line in enumerate(content):
+        stripped = line.strip()
+        lower = stripped.lower()
+        if lower.startswith("prompt"):
+            # take next non-empty line as prompt
+            j = i + 1
+            while j < len(content) and not content[j].strip():
+                j += 1
+            if j < len(content):
+                prompt = content[j].strip()
+        if stripped.startswith("References:"):
+            in_refs = True
+            continue
+        if in_refs:
+            if not stripped or stripped.startswith("#"):
+                break
+            if stripped.startswith("-") or stripped.startswith("*"):
+                stripped = stripped[1:].strip()
+            references.append(stripped)
+    return path, prompt, references
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    scenario_file, prompt, refs = parse_scenario_file(args.scenario)
+    sources = load_sources()
+
+    print(f"Scenario file: {scenario_file}")
+    print(f"Suggested prompt: {prompt or '(none)'}")
+    print("\nIndexed entries:")
+    all_refs = [str(scenario_file)] + refs
+    for ref in all_refs:
+        try:
+            idx = sources.index(ref)
+        except ValueError:
+            idx = -1
+        print(f"{idx}: {ref}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_print_codex_context.py
+++ b/tests/test_print_codex_context.py
@@ -1,0 +1,6 @@
+from scripts.print_codex_context import parse_args
+
+
+def test_parse_args():
+    args = parse_args(['--scenario', 'demo'])
+    assert args.scenario == 'demo'


### PR DESCRIPTION
## Summary
- add `scripts/print_codex_context.py` for debugging codex sources
- explain new helper in instructions
- test argument parser

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862431927fc832a958c9b680806530c