### PR TITLE
Add doku folder with starter docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Dies ist ein **`template_base`**-Repository.
 * Es wird **nicht selbst gepublished** (`publish_enabled: false`)
 * Dient als Submodul in App-Repos
 * Enthält: Setup-Tools, Referenz-App, globale Instructions, Indexing-Mechanismen, Workflow-Templates
+* Zudem liegt unter `doku/` eine Sammlung projektbegleitender Dokumente.
 
 ## 📁 Projektstruktur
 
@@ -23,6 +24,11 @@ frappe_app_template/
 │       ├── erpnext.md
 │       ├── prompts.md
 │       └── ...
+│
+├── doku/
+│   ├── overview.md
+│   ├── user_story_template.md
+│   └── guide_doctype_listing.md
 │
 ├── scripts/                            # Setup- & Sync-Werkzeuge
 │   ├── bootstrap_project.sh            # initialisiert neues App-Repo

--- a/doku/guide_doctype_listing.md
+++ b/doku/guide_doctype_listing.md
@@ -1,0 +1,8 @@
+# Doctypes, Berechtigungen und Skripte auflisten
+
+Dieser Leitfaden zeigt, wie du in einer Frappe-App die vorhandenen Doctypes samt Berechtigungen und Scripten dokumentierst.
+
+1. Erfasse alle Doctypes tabellarisch mit kurzer Beschreibung.
+2. Liste zu jedem Doctype die zugehörigen Rollen und Berechtigungsstufen aus der `permission` Tabelle auf.
+3. Dokumentiere verwendete Server- und Client-Skripte (z.B. Hooks oder `.js`-Dateien) in eigenen Abschnitten.
+4. Verweise am Ende auf weiterführende Dateien oder Links.

--- a/doku/overview.md
+++ b/doku/overview.md
@@ -1,0 +1,6 @@
+# Überblick
+
+Der Ordner `doku/` bündelt projektbezogene Dokumentationen. Hier findest du Vorlagen und Anleitungen, die beim Planen und Strukturieren deiner App helfen.
+
+* `user_story_template.md` – Vorlage zur Beschreibung von User Stories.
+* `guide_doctype_listing.md` – Leitfaden zum Auflisten von Doctypes, Berechtigungen und Skripten.

--- a/doku/user_story_template.md
+++ b/doku/user_story_template.md
@@ -1,0 +1,11 @@
+# User Story Vorlage
+
+Beschreibe Anforderungen im folgenden Format:
+
+## Titel
+**Als** `<Rolle>` **möchte ich** `<Funktion>`, **damit** `<Nutzen>`.
+
+### Akzeptanzkriterien
+- [ ] Kriterium 1
+- [ ] Kriterium 2
+- [ ] ...


### PR DESCRIPTION
## Summary
- add a `doku/` folder with starter documentation
- mention `doku/` in the intro of `README.md`
- show the new folder in the project structure tree

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68626476fabc832a99b8ea6f2de60f12