### PR TITLE
Add Mermaid diagram generation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ Jedes App-Repository sollte folgenden Hinweis enthalten:
 > codex.json ist aktiv und wird bei jedem Commit aktualisiert.
 > Erkenntnisse aus dieser App werden regelmäßig zurück in das zentrale Template synchronisiert.
 
+## 📈 Mermaid-Diagramme
+
+Legge `.mmd`-Dateien im Ordner `doku/` an und generiere die SVGs mit
+
+```bash
+./scripts/generate_diagrams.sh
+```
+
+Die Vorlage `workflow_templates/generate-mermaid.yml` automatisiert die Aktualisierung in GitHub Actions.
+
+
 ## ✨ Fazit
 
 Dieses Repository ist das zentrale Fundament zur Entwicklung modularer, wartbarer und kontextoptimierter Frappe-Projekte. Alle Submodule, Anleitungssysteme und Automatisierungen zielen auf einen sauberen Codex-Kontext ab. Neue Erkenntnisse können strukturiert in `.incoming/` zur Verfügung gestellt werden – ganz ohne Submodule pushen zu müssen.

--- a/doku/mermaid_diagrams.md
+++ b/doku/mermaid_diagrams.md
@@ -1,0 +1,27 @@
+# Mermaid Diagram Guide
+
+This project uses [Mermaid](https://mermaid.js.org/) for simple architecture diagrams.
+
+## 1. Install the CLI
+
+```bash
+npm install -g @mermaid-js/mermaid-cli
+```
+
+The CLI provides the `mmdc` command used by the helper script below.
+
+## 2. Generate diagrams
+
+Create `.mmd` files inside `doku/` and run:
+
+```bash
+./scripts/generate_diagrams.sh
+```
+
+Generated diagrams are written next to their source files with a `.svg` extension.
+
+## 3. Continuous updates
+
+A workflow template under `workflow_templates/generate-mermaid.yml` shows how to
+rebuild diagrams automatically when Markdown sources change. Copy it to
+`.github/workflows/` in your app repository if you want CI updates.

--- a/scripts/generate_diagrams.sh
+++ b/scripts/generate_diagrams.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+SRC_DIR="${1:-doku}"
+FORMAT="${FORMAT:-svg}"
+
+command -v mmdc >/dev/null 2>&1 || {
+  echo "mmdc not found. Install with: npm install -g @mermaid-js/mermaid-cli" >&2
+  exit 1
+}
+
+find "$SRC_DIR" -name '*.mmd' | while read -r file; do
+  out="${file%.mmd}.$FORMAT"
+  echo "Rendering $file -> $out"
+  mmdc -i "$file" -o "$out" -t default -b transparent
+done

--- a/workflow_templates/generate-mermaid.yml
+++ b/workflow_templates/generate-mermaid.yml
@@ -1,0 +1,31 @@
+name: generate-mermaid
+
+on:
+  push:
+    paths:
+      - 'doku/**/*.mmd'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: recursive
+      - name: Install mermaid-cli
+        run: npm install -g @mermaid-js/mermaid-cli
+      - name: Generate diagrams
+        run: ./scripts/generate_diagrams.sh
+      - name: Commit diagrams
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add doku/**/*.svg
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update diagrams"
+            git push
+          fi


### PR DESCRIPTION
## Summary
- document how to generate Mermaid diagrams
- add helper script and workflow template
- mention new docs in the README

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686264772f6c832aa7b8241367c4406c