### PR TITLE
docs: add context loading guidelines

### DIFF
--- a/instructions/how_to_prompt_codex.md
+++ b/instructions/how_to_prompt_codex.md
@@ -41,3 +41,8 @@ python scripts/print_codex_context.py --scenario my-scenario
 ```
 
 The script reads `codex.json` and the chosen markdown file under `instructions/_scenarios/`. It prints the referenced paths with their index positions and shows the suggested prompt template from the scenario file.
+## 6. Automatic context and file management
+
+Before executing any prompt, Codex should read the available documentation and the indexing strategy described in `codex.json`. Adjust the list of indexed paths when repositories grow to avoid excessive context size.
+
+Codex may create or extend configuration files such as `Price Settings` automatically. Similarly, when a new algorithm, scraping routine or API integration is required, Codex should scaffold sensible defaults or generate the necessary code once the feature is introduced.


### PR DESCRIPTION
## Summary
- update instructions on how to prompt Codex with a section about automatic context loading and file management

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68626f26e3dc832ab550e257799e21fd