### PR TITLE
Resolve jq argument limit in update_vendors

### DIFF
--- a/scripts/update_vendors.sh
+++ b/scripts/update_vendors.sh
@@ -267,7 +267,11 @@ if [ -f "$CODEX_JSON" ]; then
   existing_templates=$(jq -r 'if (.templates|type=="array") then .templates else [] end' "$CODEX_JSON" 2>/dev/null || echo "[]")
 fi
 tmp_sources=$(mktemp)
-printf '%s\n' "${sources[@]}" | jq -R '.' | jq -s '.' > "$tmp_sources"
+{
+  for src in "${sources[@]}"; do
+    printf '%s\n' "$src"
+  done
+} | jq -R -s 'split("\n")[:-1]' > "$tmp_sources"
 jq -n --argjson t "$existing_templates" --slurpfile s "$tmp_sources" '{"_comment":"Directories indexed by Codex. Adjust paths as needed.","sources":$s[0],"templates":$t}' > "$CODEX_JSON"
 rm "$tmp_sources"
 


### PR DESCRIPTION
## Summary
- avoid exceeding OS argument limits when generating codex.json

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68628d1e1fc0832aae3f9fac590e2663