### PR TITLE
Ensure setup outputs into /app folder

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -208,7 +208,7 @@ requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 EOF
 
-    cat > "$CONFIG_TARGET/setup.py" <<EOF
+    cat > "$CONFIG_TARGET/app/setup.py" <<EOF
 from setuptools import find_packages, setup
 
 with open("app/$APP_NAME/__init__.py") as f:

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -1,0 +1,21 @@
+import subprocess
+from pathlib import Path
+
+
+def test_setup_script_creates_app(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "setup.sh"
+    tmp_script = tmp_path / "setup.sh"
+    tmp_script.write_text(script_path.read_text())
+    tmp_script.chmod(0o755)
+
+    # minimal required config files
+    (tmp_path / "vendors.txt").write_text((repo_root / "vendors.txt").read_text())
+    (tmp_path / "apps.json").write_text((repo_root / "apps.json").read_text())
+
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True)
+    subprocess.run([str(tmp_script), "demoapp"], cwd=tmp_path, check=True)
+
+    assert (tmp_path / "app" / "demoapp").is_dir()
+    assert (tmp_path / "app" / "setup.py").exists()
+    assert not (tmp_path / "setup.py").exists()


### PR DESCRIPTION
## Summary
- modify setup script to write setup.py into the `/app` directory
- add regression test for setup.sh

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68637257be8c832a959244b0547ffb85