### PR TITLE
Update setup script and README notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Dieses Repository ist das **zentrale Master-Template** zur Entwicklung Codex-unt
 2. Führe `./setup.sh` aus, um das Grundgerüst und die benötigten Ordner anzulegen.
 3. Trage aktive Vendoren in `vendors.txt` ein und starte `./scripts/update_vendors.sh`.
 4. Installiere Entwickler-Abhängigkeiten mit `pip install -r requirements-dev.txt` und prüfe alles über `pytest`.
-5. Lies die [DEV_INSTRUCTIONS.md](./DEV_INSTRUCTIONS.md) und die Hinweise im Ordner [instructions/_core](instructions/_core/README.md).
+5. Installiere Bench (`pip install frappe-bench`) und stelle sicher, dass Node 18 aktiv ist (z. B. via `n 18`), bevor du `bench build` ausführst.
+6. Lies die [DEV_INSTRUCTIONS.md](./DEV_INSTRUCTIONS.md) und die Hinweise im Ordner [instructions/_core](instructions/_core/README.md).
 
 Weitere Beispiele für Daten und Schnittstellen findest du im [sample_data/README.md](sample_data/README.md).
 

--- a/setup.sh
+++ b/setup.sh
@@ -226,8 +226,8 @@ build-backend = "flit_core.buildapi"
 EOF
 fi
 
-if [ ! -f "$CONFIG_TARGET/setup.py" ]; then
-    cat > "$CONFIG_TARGET/setup.py" <<EOF
+if [ ! -f "$CONFIG_TARGET/app/setup.py" ]; then
+    cat > "$CONFIG_TARGET/app/setup.py" <<EOF
 from setuptools import find_packages, setup
 
 with open("app/$APP_NAME/__init__.py") as f:


### PR DESCRIPTION
## Summary
- add Bench and Node instructions in the README
- ensure `setup.py` is created in the `app/` folder for new apps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68637c4bbb8c832aa0226bf5d1f537ac