### PR TITLE
Fix python invocation in setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -147,6 +147,6 @@ fi
 
 
 # Ensure app skeleton exists (matching bench new-app)
-python "$CONFIG_TARGET/scripts/new_frappe_app_folder.py" "$APP_NAME" --root "$CONFIG_TARGET/app"
+python3 "$CONFIG_TARGET/scripts/new_frappe_app_folder.py" "$APP_NAME" --root "$CONFIG_TARGET/app"
 
 echo "✅ Setup complete."


### PR DESCRIPTION
## Summary
- call `new_frappe_app_folder.py` using python3 instead of python

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686390dd2af8832a8f27d06413afee41