### PR TITLE
Update Frappe instructions about Flit version

### DIFF
--- a/instructions/_core/frappe.md
+++ b/instructions/_core/frappe.md
@@ -6,6 +6,13 @@
 * Registriere Events und Scheduler-Tasks über `hooks.py`.
 * Exportiere Custom Fields oder Doctypes mit Fixtures via `bench export-fixtures`.
 * API-Aufrufe erfolgen über Whitelist-Methoden oder die REST API.
+* Nutzt du **Flit** als Build-System, muss jede App ihre Version in
+  `<appname>/__init__.py` hinterlegen:
+
+  ```python
+  # <appname>/__init__.py
+  __version__ = "0.0.1"
+  ```
 * Weitere Details findest du in der offiziellen Frappe-Dokumentation.
 
 Frappe und Bench werden über `../apps.json` verwaltet. Um zusätzliche Apps


### PR DESCRIPTION
## Summary
- mention that Flit apps need a `__version__` in `<appname>/__init__.py`
- show a short snippet

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863960e6e14832aa74b131d9a4296f7