### PR TITLE
Fix setup script path issue

### DIFF
--- a/scripts/new_frappe_app_folder.py
+++ b/scripts/new_frappe_app_folder.py
@@ -21,7 +21,7 @@ def ensure_file(path: Path, content: str) -> None:
 
 def create_app(root: Path, app_name: str) -> None:
     app_title = humanize(app_name)
-    app_dir = app_name
+    app_dir = root
 
     (app_dir / "config").mkdir(parents=True, exist_ok=True)
     (app_dir / "templates" / "pages").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- fix path handling in `new_frappe_app_folder.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68639c3ad6d0832ab39d61122422953b