### PR TITLE
Fix path for generated Frappe app

### DIFF
--- a/scripts/new_frappe_app_folder.py
+++ b/scripts/new_frappe_app_folder.py
@@ -146,7 +146,7 @@ def parse_args(argv=None):
 
 def main(argv=None):
     args = parse_args(argv)
-    create_app(Path(args.root) / args.app_name, args.app_name)
+    create_app(Path(args.root), args.app_name)
 
 
 if __name__ == "__main__":

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -21,6 +21,8 @@ def test_setup_script_creates_app(tmp_path):
     subprocess.run(["git", "init"], cwd=tmp_path, check=True)
     subprocess.run([str(tmp_script), "demoapp"], cwd=tmp_path, check=True)
 
+    assert (tmp_path / "app" / "config").is_dir()
+    assert (tmp_path / "app" / "templates").is_dir()
     assert (tmp_path / "app" / "demoapp").is_dir()
-    assert (tmp_path / "app" / "demoapp" / "pyproject.toml").exists()
-    assert (tmp_path / "app" / "demoapp" / "patches.txt").exists()
+    assert (tmp_path / "app" / "pyproject.toml").exists()
+    assert (tmp_path / "app" / "patches.txt").exists()


### PR DESCRIPTION
## Summary
- avoid creating a nested app directory when running `setup.sh`
- adjust tests for new layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863a3b313b8832a9adf026c6ee2a398