### PR TITLE
Update app scaffold script structure

### DIFF
--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -21,8 +21,10 @@ def test_setup_script_creates_app(tmp_path):
     subprocess.run(["git", "init"], cwd=tmp_path, check=True)
     subprocess.run([str(tmp_script), "demoapp"], cwd=tmp_path, check=True)
 
-    assert (tmp_path / "config").is_dir()
-    assert (tmp_path / "templates").is_dir()
-    assert (tmp_path / "demoapp").is_dir()
+    app_path = tmp_path / "demoapp"
+
+    assert (app_path / "config").is_dir()
+    assert (app_path / "templates").is_dir()
+    assert (app_path / "demoapp").is_dir()
     assert (tmp_path / "pyproject.toml").exists()
-    assert (tmp_path / "patches.txt").exists()
+    assert (app_path / "patches.txt").exists()


### PR DESCRIPTION
## Summary
- revise `new_frappe_app_folder.py` to generate an app layout similar to the `nmb_tools` vendor
- adjust tests for the new directory structure

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_b_6863d9f0bdf8832ab594e6129af8071d