### PR TITLE
Fix setup to scaffold app inside /app

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -14,7 +14,7 @@ This folder hosts the Frappe app generated from this template. A minimal setup c
    bench init frappe-bench
    cd frappe-bench
    bench new-site mysite.local
-   bench get-app ..
+   bench get-app ../app/app_name
    bench --site mysite.local install-app app_name
    bench start
    ```

--- a/instructions/_core/erpnext.md
+++ b/instructions/_core/erpnext.md
@@ -1,7 +1,7 @@
 # ERPNext Development Notes
 
 * Diese App erweitert ERPNext und sollte in einer Bench-Umgebung installiert sein.
-* Lege eigene Module unter `my_custom_app` an und verbinde sie über Hooks.
+* Lege eigene Module unter `app/my_custom_app` an und verbinde sie über Hooks.
 * Nutze die bestehenden ERPNext-Doctypes wie `Sales Invoice` oder `Customer` als Vorlage für eigene Erweiterungen.
 * Exportiere Customizations mit Fixtures, damit sie versionskontrolliert bleiben.
 * Über `hooks.py` kannst du Events wie `on_submit` abfangen und zusätzliche Logik implementieren.

--- a/instructions/_core/example_prompts.md
+++ b/instructions/_core/example_prompts.md
@@ -14,9 +14,9 @@ Codex runs the update-vendors workflow or executes the script locally to generat
 
 ## Prompt 2: Scaffold a Custom App
 
-"Create `my_new_app` with a basic DocType named `Project` and include a README."
+"Create `app/my_new_app` with a basic DocType named `Project` and include a README."
 
-Codex creates the Frappe app structure in the repository root and commits the new files.
+Codex creates the Frappe app structure inside `app/` and commits the new files.
 
 ---
 

--- a/instructions/_core/frappe.md
+++ b/instructions/_core/frappe.md
@@ -1,6 +1,6 @@
 # Frappe Development Notes
 
-* Standard-App-Struktur direkt im Repository-Stamm.
+* Standard-App-Struktur in `app/`.
 * Verwende `bench new-app` zum Erstellen neuer Apps.
 * Lege einen DocType `<appname>_Globals` für globale Einstellungen an.
 * Registriere Events und Scheduler-Tasks über `hooks.py`.

--- a/instructions/_core/prompts.md
+++ b/instructions/_core/prompts.md
@@ -21,7 +21,7 @@ In GitHub steht dafür das Workflow **update-vendors** bereit.
 
 ## Prompt 2: App Scaffold
 
-"Erzeuge in `my_custom_app` ein Grundgerüst für eine Frappe App mit DocType `Project` und einfachem List View."
+"Erzeuge in `app/my_custom_app` ein Grundgerüst für eine Frappe App mit DocType `Project` und einfachem List View."
 
 Codex legt entsprechende Dateien in der App an.
 
@@ -31,7 +31,7 @@ Codex legt entsprechende Dateien in der App an.
 
 "Füge einen Server-Side Scripting Hook hinzu, der bei `on_submit` einer Sales Invoice ausgeführt wird." 
 
-Codex aktualisiert die `hooks.py` und erstellt eine neue Python-Funktion unter `my_custom_app/my_custom_app/sales_invoice.py`.
+Codex aktualisiert die `hooks.py` und erstellt eine neue Python-Funktion unter `app/my_custom_app/my_custom_app/sales_invoice.py`.
 
 ---
 

--- a/scripts/new_frappe_app_folder.py
+++ b/scripts/new_frappe_app_folder.py
@@ -230,8 +230,8 @@ def parse_args(argv=None):
     parser.add_argument(
         "--root",
         type=Path,
-        default=Path("."),
-        help="Directory where the app folder should be created",
+        default=Path("app"),
+        help="Parent directory for app",
     )
     parser.add_argument(
         "--apps-json",

--- a/setup.sh
+++ b/setup.sh
@@ -161,6 +161,6 @@ fi
 
 
 # Ensure app skeleton exists (matching bench new-app)
-python3 "$CONFIG_TARGET/scripts/new_frappe_app_folder.py" "$APP_NAME" --root "$CONFIG_TARGET"
+python3 "$CONFIG_TARGET/scripts/new_frappe_app_folder.py" "$APP_NAME" --root "$CONFIG_TARGET/app"
 
 echo "✅ Setup complete."

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -21,10 +21,10 @@ def test_setup_script_creates_app(tmp_path):
     subprocess.run(["git", "init"], cwd=tmp_path, check=True)
     subprocess.run([str(tmp_script), "demoapp"], cwd=tmp_path, check=True)
 
-    app_path = tmp_path / "demoapp"
+    app_path = tmp_path / "app" / "demoapp"
 
     assert (app_path / "config").is_dir()
     assert (app_path / "templates").is_dir()
     assert (app_path / "demoapp").is_dir()
-    assert (tmp_path / "pyproject.toml").exists()
+    assert (app_path.parent / "pyproject.toml").exists()
     assert (app_path / "patches.txt").exists()


### PR DESCRIPTION
## Summary
- change app scaffold script to default to `/app`
- update setup script and tests for new location
- adjust docs to mention `/app`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863dd9c91c8832a8c999c7bf0fb675e