### PR TITLE
Add .gitignore to new apps

### DIFF
--- a/scripts/new_frappe_app_folder.py
+++ b/scripts/new_frappe_app_folder.py
@@ -64,6 +64,7 @@ def create_app(root: Path, app_name: str, apps_json: Path | None = None) -> None
     # Top-level files
     ensure_file(root / "README.md", README.format(app_name=app_name, app_title=app_title))
     ensure_file(root / "license.txt", MIT_LICENSE)
+    ensure_file(root / ".gitignore", GITIGNORE)
     dependency = guess_frappe_dependency(apps_json) if apps_json else None
     pyproject = PYPROJECT.format(app_name=app_name)
     if dependency:
@@ -148,6 +149,21 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+"""
+
+GITIGNORE = """# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Node and bench outputs
+node_modules/
+sites/assets/
+sites/*/public/
+
+# Logs
+*.log
 """
 
 PYPROJECT = """[project]

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -26,5 +26,10 @@ def test_setup_script_creates_app(tmp_path):
     assert (app_path / "config").is_dir()
     assert (app_path / "templates").is_dir()
     assert (app_path / "demoapp").is_dir()
-    assert (app_path.parent / "pyproject.toml").exists()
+    root = app_path.parent
+
+    assert (root / "pyproject.toml").exists()
+    assert (root / "README.md").exists()
+    assert (root / "license.txt").exists()
+    assert (root / ".gitignore").exists()
     assert (app_path / "patches.txt").exists()


### PR DESCRIPTION
## Summary
- include a default `.gitignore` when generating new Frappe app folders
- test that README, license, `.gitignore`, and `pyproject.toml` exist at `app/`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863e2382eb0832a8d16873453fa4e1b