### PR TITLE
Update docs for new app gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Dieses Repository ist das **zentrale Master-Template** zur Entwicklung Codex-unt
 
 1. Klone dieses Repository oder binde es als Submodul in dein App-Projekt ein.
 2. Führe `./setup.sh` aus, um das Grundgerüst und die benötigten Ordner anzulegen.
+   Dabei wird sofort ein App-Ordner inklusive `app/.gitignore` erstellt.
 3. Trage aktive Vendoren in `vendors.txt` ein und starte `./scripts/update_vendors.sh`.
 4. Installiere Entwickler-Abhängigkeiten mit `pip install -r requirements-dev.txt` und prüfe alles über `pytest`.
 5. Installiere Bench (`pip install frappe-bench`) und stelle sicher, dass Node 18 aktiv ist (z. B. via `n 18`), bevor du `bench build` ausführst.
@@ -160,7 +161,8 @@ git init -b develop my_app && cd my_app
 
 git submodule add https://github.com/your-org/frappe_app_template
 ./frappe_app_template/setup.sh
-# erstellt auch sofort das App-Verzeichnis
+# erstellt auch sofort das App-Verzeichnis inklusive app/.gitignore
+# (via `scripts/new_frappe_app_folder.py`)
 # legt bei Bedarf auch eine leere .gitmodules an
 
 nano vendors.txt

--- a/instructions/_core/submodule_usage.md
+++ b/instructions/_core/submodule_usage.md
@@ -26,7 +26,7 @@ Edit these files to add your desired vendor slugs and integration profiles.
 
 ## 2. Initialising the Environment
 
-Run the setup script inside the submodule to clone the vendor apps and generate `codex.json`. The script also copies the GitHub workflow files to the parent repository when they are missing so that CI runs automatically:
+Run the setup script inside the submodule to clone the vendor apps and generate `codex.json`. The script also copies the GitHub workflow files to the parent repository when they are missing so that CI runs automatically. It relies on `scripts/new_frappe_app_folder.py` to create the `app/` directory and its `app/.gitignore`:
 
 ```bash
 cd template

--- a/setup.sh
+++ b/setup.sh
@@ -161,6 +161,7 @@ fi
 
 
 # Ensure app skeleton exists (matching bench new-app)
+echo "ℹ️  Creating app skeleton (includes app/.gitignore)"
 python3 "$CONFIG_TARGET/scripts/new_frappe_app_folder.py" "$APP_NAME" --root "$CONFIG_TARGET/app"
 
 echo "✅ Setup complete."


### PR DESCRIPTION
## Summary
- mention `app/.gitignore` creation when using the setup script in README
- explain `new_frappe_app_folder.py` usage in submodule guide
- add note in `setup.sh` about the gitignore creation

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6863f5b29108832a93af6f8a878a80ca