### PR TITLE
Add Project Request Doctype and webform

### DIFF
--- a/app/zep/hooks.py
+++ b/app/zep/hooks.py
@@ -7,3 +7,8 @@ app_icon = "octicon octicon-file-directory"
 app_color = "grey"
 app_email = ""
 app_license = "MIT"
+
+# Include client script for Project Request
+doctype_js = {
+    "Project Request": "public/js/project_request.js"
+}

--- a/app/zep/zep/doctype/project_request/project_request.json
+++ b/app/zep/zep/doctype/project_request/project_request.json
@@ -1,0 +1,37 @@
+{
+  "doctype": "DocType",
+  "name": "Project Request",
+  "module": "ZEP",
+  "custom": 1,
+  "autoname": "format:{project_name}-{####}",
+  "fields": [
+    {
+      "fieldname": "project_name",
+      "fieldtype": "Data",
+      "label": "Project Name",
+      "reqd": 1
+    },
+    {
+      "fieldname": "customer",
+      "fieldtype": "Link",
+      "label": "Customer",
+      "options": "Customer",
+      "reqd": 0
+    },
+    {
+      "fieldname": "contact_name",
+      "fieldtype": "Data",
+      "label": "Contact Name"
+    },
+    {
+      "fieldname": "contact_email",
+      "fieldtype": "Data",
+      "label": "Contact Email"
+    },
+    {
+      "fieldname": "contact_phone",
+      "fieldtype": "Data",
+      "label": "Contact Phone"
+    }
+  ]
+}

--- a/app/zep/zep/doctype/project_request/project_request.py
+++ b/app/zep/zep/doctype/project_request/project_request.py
@@ -1,0 +1,20 @@
+import frappe
+from frappe.model.document import Document
+
+class ProjectRequest(Document):
+    pass
+
+@frappe.whitelist()
+def create_customer(docname):
+    doc = frappe.get_doc('Project Request', docname)
+    if doc.customer:
+        return doc.customer
+
+    customer = frappe.get_doc({
+        'doctype': 'Customer',
+        'customer_name': doc.contact_name or doc.project_name
+    })
+    customer.insert(ignore_permissions=True)
+    doc.customer = customer.name
+    doc.save(ignore_permissions=True)
+    return customer.name

--- a/app/zep/zep/public/js/project_request.js
+++ b/app/zep/zep/public/js/project_request.js
@@ -1,0 +1,18 @@
+frappe.ui.form.on('Project Request', {
+    refresh(frm) {
+        if (!frm.doc.customer && !frm.is_new()) {
+            frm.add_custom_button(__('Create Customer'), () => {
+                frappe.call({
+                    method: 'zep.zep.doctype.project_request.project_request.create_customer',
+                    args: { docname: frm.doc.name },
+                    callback: function(r) {
+                        if (!r.exc && r.message) {
+                            frm.set_value('customer', r.message);
+                            frm.reload_doc();
+                        }
+                    }
+                });
+            });
+        }
+    }
+});

--- a/app/zep/zep/web_form/projektanfrage/projektanfrage.json
+++ b/app/zep/zep/web_form/projektanfrage/projektanfrage.json
@@ -1,0 +1,15 @@
+{
+  "doctype": "Web Form",
+  "name": "projektanfrage",
+  "module": "ZEP",
+  "is_standard": false,
+  "doc_type": "Project Request",
+  "fields": [
+    {"fieldname": "project_name", "label": "Project Name", "fieldtype": "Data", "reqd": 1},
+    {"fieldname": "contact_name", "label": "Contact Name", "fieldtype": "Data"},
+    {"fieldname": "contact_email", "label": "Contact Email", "fieldtype": "Data"},
+    {"fieldname": "contact_phone", "label": "Contact Phone", "fieldtype": "Data"}
+  ],
+  "success_message": "Project request submitted",
+  "allow_login": false
+}

--- a/app/zep/zep/web_form/projektanfrage/projektanfrage.py
+++ b/app/zep/zep/web_form/projektanfrage/projektanfrage.py
@@ -1,11 +1,6 @@
-# Placeholder web form module for Projektanfrage
-
 import frappe
 
-
 def get_context(context):
-    """Return context for the projektanfrage web form."""
-    context.update({
-        "message": "Hello from Projektanfrage web form"
-    })
+    """Context for projektanfrage web form"""
+    context.no_cache = 1
     return context


### PR DESCRIPTION
## Summary
- add Project Request doctype with optional Customer link and custom autoname
- create matching Web Form `projektanfrage`
- add client script and server method to create a Customer from a Project Request
- hook the client script via `hooks.py`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68642e244a7c832ab65955988deab21a