### PR TITLE
Update patch instructions link to v15 docs

### DIFF
--- a/scripts/new_frappe_app_folder.py
+++ b/scripts/new_frappe_app_folder.py
@@ -226,7 +226,7 @@ docstring-code-format = true
 
 PATCHES = """[pre_model_sync]
 # Patches added in this section will be executed before doctypes are migrated
-# Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
+# Read docs to understand patches: https://frappeframework.com/docs/v15/user/en/database-migrations
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated"""


### PR DESCRIPTION
## Summary
- update reference link in `new_frappe_app_folder.py` to use the v15 documentation URL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686481c6e3fc832aa5412f64e17e7538