### PR TITLE
Add tagged prompt parsing

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,7 @@
+# Project Prompts
+
+[Doctype] Create a Customer doctype with address field.
+[Website] Add a home page template for customers.
+[API] Provide a REST endpoint to fetch customer data.
+[Doctype,API] Add validation when a customer is created via the API.
+[Website] Document the API on the website.

--- a/tests/test_prompt_tasks.py
+++ b/tests/test_prompt_tasks.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from scripts import generate_index
+
+
+def test_parse_prompts(tmp_path: Path):
+    prompts = tmp_path / "projects.md"
+    prompts.write_text("\n".join([
+        "[Doctype] Create",
+        "[API,Website] Build"
+    ]))
+
+    tasks = generate_index.parse_prompts(tmp_path)
+    assert tasks["Doctype"] == ["- Create"]
+    assert tasks["API"] == ["- Build"]
+    assert tasks["Website"] == ["- Build"]
+
+
+def test_index_includes_tasks(tmp_path: Path):
+    (tmp_path / "instructions" / "vendors").mkdir(parents=True)
+    (tmp_path / "vendor" / "foo").mkdir(parents=True)
+    (tmp_path / "projects.md").write_text("[API] Example task")
+    (tmp_path / "PROJECT.md").write_text("## Tags\nfoo")
+
+    vendor_links = generate_index.generate_vendor_summaries(tmp_path)
+    tags = generate_index.extract_tags(tmp_path)
+    tag_map = generate_index.map_tags_to_vendors(tags, tmp_path)
+    tasks = generate_index.parse_prompts(tmp_path)
+    generate_index.write_index(vendor_links, tags, tag_map, tmp_path, tasks)
+
+    text = (tmp_path / "instructions" / "_INDEX.md").read_text()
+    assert "## Tasks" in text
+    assert "### API" in text
+    assert "Example task" in text


### PR DESCRIPTION
## Summary
- add a `projects.md` backlog with tagged prompts
- extend `generate_index.py` to parse tagged prompt lines
- output task lists grouped by tag
- test prompt parsing and index generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68648207f9a4832ab8078f362d75a7eb