### PR TITLE
Add file extension index tool

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -5,3 +5,23 @@
 [API] Provide a REST endpoint to fetch customer data.
 [Doctype,API] Add validation when a customer is created via the API.
 [Website] Document the API on the website.
+
+## File Index
+
+`scripts/create_index.py` scans the project and groups files by extension. The default set reflects typical Frappe projects:
+
+- `.py` – Python modules
+- `.js` – client scripts
+- `.html` – Jinja templates
+- `.css`, `.scss` – styles
+- `.json` – fixtures or configuration
+- `.md` – documentation
+- `.vue` – Vue components
+- `.jinja` – advanced templates
+
+Run the script to generate `file_index.json`:
+
+```bash
+python scripts/create_index.py
+```
+

--- a/scripts/create_index.py
+++ b/scripts/create_index.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Create a simple file index grouped by extension."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_EXTENSIONS = [
+    "py",
+    "js",
+    "json",
+    "html",
+    "css",
+    "scss",
+    "md",
+    "vue",
+    "jinja",
+]
+
+
+def build_index(root: Path, extensions: list[str] | None = None) -> dict[str, list[str]]:
+    """Return mapping of extension -> list of relative file paths."""
+    mapping: dict[str, list[str]] = {}
+    for path in root.rglob("*"):
+        if path.is_file():
+            ext = path.suffix.lower().lstrip(".") or "no_ext"
+            if extensions is None or ext in extensions:
+                mapping.setdefault(ext, []).append(str(path.relative_to(root)))
+    return mapping
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Create a JSON index of project files grouped by extension"
+    )
+    parser.add_argument("--root", type=Path, default=Path("."), help="Project root")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("file_index.json"),
+        help="Output JSON file",
+    )
+    args = parser.parse_args(argv)
+    index = build_index(args.root, DEFAULT_EXTENSIONS)
+    args.output.write_text(json.dumps(index, indent=2))
+    print(f"Index written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_create_index.py
+++ b/tests/test_create_index.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import json
+from scripts import create_index
+
+
+def test_build_index(tmp_path: Path):
+    (tmp_path / "a.py").write_text("")
+    (tmp_path / "b.js").write_text("")
+    (tmp_path / "c.txt").write_text("")
+
+    index = create_index.build_index(tmp_path, ["py", "js"])
+    assert set(index.keys()) == {"py", "js"}
+    assert index["py"] == ["a.py"]
+    assert index["js"] == ["b.js"]
+
+
+def test_cli(tmp_path: Path, monkeypatch):
+    out = tmp_path / "out.json"
+    args = ["--root", str(tmp_path), "--output", str(out)]
+    (tmp_path / "file.py").write_text("")
+    create_index.main(args)
+    data = json.loads(out.read_text())
+    assert data
+    assert "py" in data


### PR DESCRIPTION
## Summary
- add `create_index.py` to generate file index by extension
- document new script and common Frappe extensions in `projects.md`
- add tests for file index builder and CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68648d6439a0832a95516a668e9b75aa