### PR TITLE
Remove codex references from tests

### DIFF
--- a/tests/test_print_codex_context.py
+++ b/tests/test_print_codex_context.py
@@ -1,6 +1,6 @@
-from scripts.print_codex_context import parse_args
+from scripts.new_frappe_app_folder import parse_args
 
 
 def test_parse_args():
-    args = parse_args(['--scenario', 'demo'])
-    assert args.scenario == 'demo'
+    args = parse_args(['demoapp'])
+    assert args.app_name == 'demoapp'


### PR DESCRIPTION
## Summary
- stop referencing codex-specific tooling in tests
- keep vendor and setup tests validating their scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68667bbd76d4832a88afa49c533af8f7