### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.1
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.56.0
+    hooks:
+      - id: eslint
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.3
+    hooks:
+      - id: prettier
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.16.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus"]

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Then run the setup script directly from within the `frappe-bench` directory:
 
 The script will:
 
-* use `bench new-app` to generate a new Frappe app under `apps/my_app/` (you will be prompted interactively)
-* initialize a Git repository in `apps/my_app/`
-* link the `frappe_app_template` as a submodule in `apps/my_app/frappe_app_template`
-* copy required template files into the root of your new app (e.g. `README.md`, `.github/`, `AGENTS.md`, `instructions/`, etc.)
-* prepare for GitHub push to your private repository (e.g. `github.com/mygithubacc/frappe-apps/`my\_app)
+- use `bench new-app` to generate a new Frappe app under `apps/my_app/` (you will be prompted interactively)
+- initialize a Git repository in `apps/my_app/`
+- link the `frappe_app_template` as a submodule in `apps/my_app/frappe_app_template`
+- copy required template files into the root of your new app (e.g. `README.md`, `.github/`, `AGENTS.md`, `instructions/`, etc.)
+- prepare for GitHub push to your private repository (e.g. `github.com/mygithubacc/frappe-apps/`my_app)
 
 ### GitHub Configuration
 
@@ -54,6 +54,7 @@ apps/my_app/.config/github_settings.json
         ├── apps.json                      # list of submodules
         ├── custom_vendors.json            # custom vendor definitions
         ├── vendors.txt                    # common vendors
+        ├── .pre-commit-config.yaml        # git hook definitions
         ├── .github/
         │   └── workflows/
         │       ├── ci.yml
@@ -76,18 +77,20 @@ pre-commit install
 
 Our pre-configured hooks format code automatically using:
 
-* ruff (Python)
-* eslint (JavaScript)
-* prettier (Markdown, HTML, etc.)
-* pyupgrade (Python modernizer)
+- ruff (Python)
+- eslint (JavaScript)
+- prettier (Markdown, HTML, etc.)
+- pyupgrade (Python modernizer)
+
+All hook definitions live in `.pre-commit-config.yaml` at the repository root.
 
 ### CI & Automation
 
 This template comes with GitHub Actions workflows for:
 
-* CI testing
-* automated vendor submodule updates
-* commit linting and validation
+- CI testing
+- automated vendor submodule updates
+- commit linting and validation
 
 ### License
 
@@ -96,3 +99,21 @@ MIT
 ---
 
 For full Codex compatibility and developer productivity, follow the structural conventions and use the agent files provided.
+
+### How to Code
+
+The Codex agent follows the instructions in `AGENTS.md`. Key rules are:
+
+- Remove one-time helper files once used.
+- Keep workflows and configuration files logically organized.
+- Update existing files when they diverge from `README.md` or `AGENTS.md`.
+- Keep `README.md` and `AGENTS.md` synchronized.
+- Maintain this **How to Code** section with available flags and active instructions.
+
+Available flags:
+
+- `--no-agent`
+- `--create-tasks`
+- `--start`
+
+Vendor-specific instructions under `instructions/vendor_profiles/<vendor>` may override the defaults here.


### PR DESCRIPTION
## Summary
- configure pre-commit hooks for ruff, eslint, prettier and pyupgrade
- document `.pre-commit-config.yaml`
- add a "How to Code" section with guidance and flags

## Testing
- `pytest -q` *(fails: ImportError)*
- `pre-commit run --files README.md .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_b_6866bb5cd244832abeb68b4069cad157