### PR TITLE
Add script docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ The script will:
 * copy required template files into the root of your new app (e.g. `README.md`, `.github/`, `AGENTS.md`, `instructions/`, etc.)
 * prepare for GitHub push to your private repository (e.g. `github.com/mygithubacc/frappe-apps/`my\_app)
 
+### Scripts
+
+The `scripts/` directory contains helper tools:
+
+* **`generate_index.py`** – builds the documentation index under `instructions/`.
+  ```bash
+  python scripts/generate_index.py
+  ```
+* **`create_index.py`** – creates a JSON mapping of files grouped by extension.
+  ```bash
+  python scripts/create_index.py --root . --output index.json
+  ```
+* **`new_frappe_app_folder.py`** – generates a minimal Frappe app skeleton.
+  ```bash
+  python scripts/new_frappe_app_folder.py my_app --root app
+  ```
+
+
 ### GitHub Configuration
 
 Important credentials, patterns and GitHub tokens should be stored in:
@@ -96,3 +114,20 @@ MIT
 ---
 
 For full Codex compatibility and developer productivity, follow the structural conventions and use the agent files provided.
+
+### How to Code
+
+Follow these active agent instructions:
+
+- Remove helper files once they are no longer needed.
+- Keep workflows, scripts and configuration consistent with this README and AGENTS.md.
+- Update existing files if they drift from the documented structure.
+- Keep README.md and AGENTS.md synchronized.
+- Vendor-specific AGENTS.md files can override these rules.
+
+Supported flags:
+
+- `--no-agent` – use the prompt as the main instruction set.
+- `--create-tasks` – output tasks without changing code.
+- `--start` – (re)initialize the project according to the agent files.
+


### PR DESCRIPTION
## Summary
- document available Python helper scripts
- add `How to Code` reference section

## Testing
- `pytest -q` *(fails: cannot import scripts modules)*

------
https://chatgpt.com/codex/tasks/task_b_6866bb5fdafc832ab7d92189d00838b8