### PR TITLE
Add workflow template docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ This template comes with GitHub Actions workflows for:
 - automated vendor submodule updates
 - commit linting and validation
 
+Workflow examples are stored in `workflow_templates/`. Copy them into
+`.github/workflows/` in your app repository and adjust them as needed.
+The [workflow_templates.md](doc/workflow_templates.md) document explains what
+each template does.
+
 ### License
 
 MIT

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -4,3 +4,5 @@ Der Ordner `doc/` bündelt projektbezogene Dokumentationen. Hier findest du Vorl
 
 * `user_story_template.md` – Vorlage zur Beschreibung von User Stories.
 * `guide_doctype_listing.md` – Leitfaden zum Auflisten von Doctypes, Berechtigungen und Skripten.
+* `mermaid_diagrams.md` – Tipps zum Erstellen und Aktualisieren von Mermaid-Diagrammen.
+* `workflow_templates.md` – kurze Erklärungen zu den mitgelieferten GitHub-Workflows.

--- a/doc/workflow_templates.md
+++ b/doc/workflow_templates.md
@@ -1,0 +1,9 @@
+# Workflow Templates
+
+This repository provides minimal GitHub Actions workflows that you can reuse in your own app projects. They live in the `workflow_templates/` folder.
+
+- **`ci.yml`** – installs Python dependencies and acts as a starting point for custom CI steps. Extend it with linting or packaging commands as needed.
+- **`generate-mermaid.yml`** – rebuilds diagrams from `.mmd` files in `doc/` and pushes the resulting `.svg` files back to the repository.
+- **`test.yml`** – runs unit tests using `pytest` and performs a simple ShellCheck on scripts.
+
+Copy any of these files to `.github/workflows/` in your app repository. The `setup.sh` script does this automatically when you bootstrap a new app, but you can also copy them manually and adjust branches or Python versions to your needs.


### PR DESCRIPTION
## Summary
- document workflow templates for easy reuse
- mention workflow template docs in overview and README

## Testing
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_b_6866c294664c832a9665e63fa6bf582b