### PR TITLE
Update vendor workflow trigger paths

### DIFF
--- a/.github/workflows/update-vendors.yml
+++ b/.github/workflows/update-vendors.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - vendors.txt
       - custom_vendors.json
-      - vendor_profiles/**
+      # vendor profiles don't trigger workflow on change
   workflow_dispatch:
 
 concurrency:
@@ -52,8 +52,11 @@ jobs:
             git add vendor
           fi
           git add .gitmodules apps.json vendors.txt
-          if [ -d vendor_profiles ]; then
-            git add vendor_profiles
+          if [ -d instructions/vendor_profiles ]; then
+            git add instructions/vendor_profiles
+          fi
+          if [ -d instructions ]; then
+            git add instructions
           fi
           if git diff --cached --quiet; then
             echo "No changes to commit"


### PR DESCRIPTION
## Summary
- stop triggering the update-vendors workflow for profile changes
- still stage instruction files when the workflow does run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866efe8fa00832a95d27007f958edaf