### PR TITLE
Add publish_app release helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ apps/my_app/.config/github_settings.json
         │   ├── remove_submodule.sh        # remove unwanted vendor
         │   └── update_vendors.sh          # sync vendor submodules
         │   └── publish_app.sh             # manual publish app without dev files --> create pull request with new tag <vx.x.x> auto upscaling with choice of dev-stable <vx.x.x+1>, test-stable <vx.x+1.0>, major <vx+1.0.0>
+        │                                   # run with -h to see options
         ├── .pre-commit-config.yaml        # git hook definitions
         ├── .github/
         │   └── workflows/

--- a/scripts/publish_app.sh
+++ b/scripts/publish_app.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [dev-stable|test-stable|major]" >&2
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [ $# -ne 1 ]; then
+  usage
+  exit 1
+fi
+
+LEVEL="$1"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "❌ Not a git repository" >&2
+  exit 1
+fi
+
+if ! git diff-index --quiet HEAD --; then
+  echo "❌ Working tree has uncommitted changes" >&2
+  exit 1
+fi
+
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+VER=${LAST_TAG#v}
+IFS='.' read -r MAJOR MINOR PATCH <<<"$VER"
+MAJOR=${MAJOR:-0}
+MINOR=${MINOR:-0}
+PATCH=${PATCH:-0}
+case "$LEVEL" in
+  dev-stable)
+    PATCH=$((PATCH + 1))
+    ;;
+  test-stable)
+    MINOR=$((MINOR + 1))
+    PATCH=0
+    ;;
+  major)
+    MAJOR=$((MAJOR + 1))
+    MINOR=0
+    PATCH=0
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac
+NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+
+echo "Creating release commit for $NEW_TAG"
+DEV_PATHS=("instructions" "vendor_profiles" "sample_data" "tests")
+for p in "${DEV_PATHS[@]}"; do
+  if [ -e "$p" ]; then
+    git rm -r --cached "$p" >/dev/null 2>&1 || true
+  fi
+done
+
+if git diff --cached --quiet; then
+  echo "No changes to commit for release" >&2
+else
+  git commit -m "chore: release $NEW_TAG"
+fi
+
+git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+
+if git remote get-url origin >/dev/null 2>&1; then
+  echo "Pushing tag $NEW_TAG"
+  git push origin "$NEW_TAG"
+fi
+
+if command -v gh >/dev/null 2>&1 && git remote get-url origin >/dev/null 2>&1; then
+  gh pr create --title "Release $NEW_TAG" --body "Release $NEW_TAG" --base main || true
+fi
+

--- a/tests/test_publish_app.py
+++ b/tests/test_publish_app.py
@@ -1,0 +1,33 @@
+import subprocess
+from pathlib import Path
+
+
+def prepare_repo(tmp_path, script_name):
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / script_name
+    tmp_scripts = tmp_path / "scripts"
+    tmp_scripts.mkdir()
+    dest = tmp_scripts / script_name
+    dest.write_text(script_path.read_text())
+    dest.chmod(0o755)
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True)
+    (tmp_path / "README.md").write_text("init")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, check=True)
+    return dest
+
+
+def test_publish_app_creates_patch_tag(tmp_path):
+    script = prepare_repo(tmp_path, "publish_app.sh")
+    subprocess.run(["git", "tag", "v1.2.3"], cwd=tmp_path, check=True)
+    subprocess.run([str(script), "dev-stable"], cwd=tmp_path, check=True)
+    tags = subprocess.check_output(["git", "tag"], cwd=tmp_path).decode().split()
+    assert "v1.2.4" in tags
+
+
+def test_publish_app_creates_major_tag(tmp_path):
+    script = prepare_repo(tmp_path, "publish_app.sh")
+    subprocess.run(["git", "tag", "v0.1.0"], cwd=tmp_path, check=True)
+    subprocess.run([str(script), "major"], cwd=tmp_path, check=True)
+    tags = subprocess.check_output(["git", "tag"], cwd=tmp_path).decode().split()
+    assert "v1.0.0" in tags


### PR DESCRIPTION
## Summary
- implement `scripts/publish_app.sh` for manual releases
- document how to show help in README
- test tag increment logic for `publish_app.sh`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866efe4272c832a8d4c459f0a94eabf