### PR TITLE
Add verbose option to setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Then run the setup script directly from within the `frappe-bench` directory:
 
 ```bash
 ./frappe_app_template/setup.sh my_app
+# for detailed output use --verbose
+./frappe_app_template/setup.sh --verbose my_app
 ```
 
 The script will:


### PR DESCRIPTION
## Summary
- support `-v/--verbose` in `setup.sh`
- document verbose usage in README
- print progress info when copying files and creating resources

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6866fae4c4f8832a87670577645c587d