### PR TITLE
Fix setup.sh path handling and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The script will:
 - initialize a Git repository in `apps/my_app/`
 - link the `frappe_app_template` as a submodule in `apps/my_app/frappe_app_template`
 - copy required template files into the root of your new app (e.g. `README.md`, `.github/`, `AGENTS.md`, `instructions/`, `scripts/` etc.)
+- create or update `.env` in your bench directory to store a GitHub `API_KEY`
 - create new remote repo <path from .config>/my_app
 - prepare for GitHub push to your private repository (e.g. `github.com/mygithubacc/frappe-apps/`my_app)
 - pushes new generated app repo to remote develop branch


### PR DESCRIPTION
## Summary
- update setup.sh to create app directories under bench apps folder
- place `.env` in bench root and remove unused instructions/_core step
- copy workflow templates and scripts into new app
- document `.env` file creation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6867023dfffc832a8f6dc378d67d86e7