### PR TITLE
Add clarifying comments and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,5 +254,8 @@ Codex can be guided with these flags:
 - `--update-agent` &ndash; Rewrite `AGENTS.md` according to the prompt and update the project afterwards.
 - `--update-readme` &ndash; Rewrite `README.md` according to the prompt and adjust the repository.
 - `--update-docs` &ndash; Work exclusively on documentation under `doc/`.
+- `--update-scripts` &ndash; Review and adapt files in `scripts/` and `setup.sh`.
+- `--update-workflows` &ndash; Update files in `.github/workflows/` to match the docs.
+- `--update-comments` &ndash; Add concise comments that clarify why code exists.
 
 Inactive instructions, if any, appear here as "not active" when they are commented out in `AGENTS.md`.

--- a/scripts/generate_diagrams.sh
+++ b/scripts/generate_diagrams.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# generate_diagrams.sh: render all .mmd files under doc/ to images
 set -euo pipefail
 
 SRC_DIR="${1:-doc}"

--- a/scripts/publish_app.sh
+++ b/scripts/publish_app.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# publish_app.sh: tag the repository and optionally open a release PR
 set -euo pipefail
 
 usage() {

--- a/scripts/remove_submodule.sh
+++ b/scripts/remove_submodule.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# remove_submodule.sh: delete a vendor submodule and its instructions
 set -euo pipefail
 
 # Prevent execution inside the frappe_app_template submodule

--- a/scripts/update_vendors.sh
+++ b/scripts/update_vendors.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# update_vendors.sh: sync vendor directories using vendor_profiles and vendors.txt
 set -euo pipefail
 
 if ! command -v jq >/dev/null 2>&1; then

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# setup.sh: bootstrap a new Frappe app using template resources
 set -euo pipefail
 
 VERBOSE=0

--- a/tests/test_publish_app.py
+++ b/tests/test_publish_app.py
@@ -1,3 +1,4 @@
+"""test_publish_app.py: verify publish_app.sh tags releases correctly"""
 import subprocess
 from pathlib import Path
 

--- a/tests/test_remove_submodule.py
+++ b/tests/test_remove_submodule.py
@@ -1,3 +1,4 @@
+"""test_remove_submodule.py: ensure submodule cleanup works"""
 import subprocess
 from pathlib import Path
 

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -1,3 +1,4 @@
+"""test_setup_script.py: check that setup.sh creates the minimal app layout"""
 import os
 import subprocess
 from pathlib import Path

--- a/tests/test_update_vendors.py
+++ b/tests/test_update_vendors.py
@@ -1,3 +1,4 @@
+"""test_update_vendors.py: verify vendor update script behavior"""
 import os
 import subprocess
 import json


### PR DESCRIPTION
## Summary
- document all comment and workflow flags in README
- annotate key scripts with short descriptions
- add file-level docstrings to tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686717a4e6ac832aaa8639ab8d797d91