### PR TITLE
Improve setup script robustness

### DIFF
--- a/doc/setup_sh.md
+++ b/doc/setup_sh.md
@@ -20,7 +20,7 @@
 - Wenn **nicht vorhanden**:
   - `bench new-app` wird mit vorgegebenen Werten ausgeführt
   - App-Struktur wird angelegt
-- Erstellt `.env` (falls nicht vorhanden)
+- Erstellt `.env` im Bench-Hauptordner (falls nicht vorhanden)
 - Liest / schreibt Werte wie `API_KEY`, `GITHUB_USER`, `REPO_NAME`, `REPO_PATH`
 
 ---


### PR DESCRIPTION
## Summary
- fix environment file handling in `setup.sh`
- skip git init when repo already present
- add fetch/rebase logic with optional force-push
- handle non-interactive runs
- document `.env` location in `setup_sh.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68673cc158c4832abf8f25e08ef205fa