### PR TITLE
Update docs and mermaid guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,9 +205,7 @@ This makes `PROJECT.md` a central place for:
 
 ## Mermaid
 
-Mermaid diagrams should be created consistently. The following guidelines support standardization.  
-If Codex deems a diagram useful and generates one, this section will be updated with new rules.
-
-- if this happens for the first time, replace this section with new instructions to standardize the following mermaids
-- structure mermaids logically and use different shapes for distinct purposes
-- e.g., functions as rounded shapes, instructions as rectangles – depending on what the diagram illustrates and what groupings make sense
+All diagrams are stored as `.mmd` files under `doc/` and rendered to `.svg` using `scripts/generate_diagrams.sh`.
+Use `flowchart TD` unless a different chart type better suits the information.
+Represent files or resources with rectangular nodes and scripts or commands with rounded nodes.
+Keep each diagram focused on a single workflow to stay concise.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Codex processes this repository based on the rules in `AGENTS.md`. The following
 - Update existing files if they do not match the documentation in `README.md` or the instructions in `AGENTS.md`.
 - Keep `README.md` and `AGENTS.md` synchronized.
 - Ensure scripts under `scripts/` reflect what the README describes.
+- Store Mermaid diagrams as `.mmd` files in `doc/` and use `flowchart TD` with files as rectangles and scripts as rounded nodes.
 - Maintain this "How to Code" section so it lists available flags, how Codex is influenced and which instructions are active or disabled.
 - Use `--create-tasks` when prompts risk exceeding context limits.
 - Check vendor-specific instructions under `instructions/vendor_profiles/<vendorname>/AGENTS.md`; those override the main `AGENTS.md` when present.

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -6,4 +6,5 @@ Der Ordner `doc/` bündelt projektbezogene Dokumentationen. Hier findest du Vorl
 - `guide_doctype_listing.md` – Leitfaden zum Auflisten von Doctypes, Berechtigungen und Skripten.
 - `mermaid_diagrams.md` – Tipps zum Erstellen und Aktualisieren von Mermaid-Diagrammen.
 - `workflow_templates.md` – kurze Erklärungen zu den mitgelieferten GitHub-Workflows.
-- `vendor_management.md` – beschreibt, wie `vendors.txt`, `custom_vendors.json` und das Skript `update_vendors.sh` zusammenarbeiten.
+- `vendor_management.md` – beschreibt, wie `vendors.txt`, `custom_vendors.json` und die Skripte zur Pflege der Vendor-Submodule zusammenarbeiten. Ein Diagramm in `vendor_update_flow.mmd` visualisiert den Ablauf.
+- `release_process.md` – erklärt den Ablauf für neue Releases mittels `publish_app.sh`.

--- a/doc/release_process.md
+++ b/doc/release_process.md
@@ -1,0 +1,15 @@
+# Release Process
+
+Use `publish_app.sh` to create tags and optional release pull requests.
+
+```bash
+./scripts/publish_app.sh <dev-stable|test-stable|major>
+```
+
+The argument decides which part of the version is bumped:
+
+- `dev-stable` – increase the patch level.
+- `test-stable` – increase the minor version and reset patch.
+- `major` – increase the major version and reset minor and patch.
+
+The script checks for an existing clean git repository, creates a release commit if needed, tags the new version and pushes the tag. When the GitHub CLI is installed, it also opens a release PR on the `main` branch.

--- a/doc/setup_sh.md
+++ b/doc/setup_sh.md
@@ -81,3 +81,5 @@
 ## 🔒 Sicherheit & Robustheit
 - `set -euo pipefail`: Bricht bei Fehlern oder nicht gesetzten Variablen ab
 - Zugriff auf `.env` sicher via `chmod 600`
+
+Weitere Hinweise zur Verwaltung von Vendoren findest du in [vendor_management.md](vendor_management.md).

--- a/doc/vendor_management.md
+++ b/doc/vendor_management.md
@@ -14,6 +14,33 @@ The script reads both `vendors.txt` and `custom_vendors.json`, resolves the repo
 
 Submodules removed from the lists are deleted, and the updated state is written back to `apps.json`.
 
+## Other helper scripts
+
+- `clone_submodules.sh` – clones vendor submodules listed in `vendors.txt` without updating existing entries.
+- `remove_submodule.sh` – removes a specific vendor submodule and its instructions directory.
+
+Both scripts live in the `scripts/` folder and are useful for manual vendor maintenance.
+
 ## GitHub Workflow
 
-`update-vendors.yml` triggers this script automatically whenever `vendors.txt` or `custom_vendors.json` change. The workflow commits updated submodules and documentation back to the repository.
+`update-vendors.yml` triggers `update_vendors.sh` automatically whenever `vendors.txt` or `custom_vendors.json` change. The workflow commits updated submodules and documentation back to the repository.
+
+## Diagram
+
+A high level flow of the vendor update process is captured in `vendor_update_flow.mmd`. Run `./scripts/generate_diagrams.sh` to render the diagram as SVG.
+
+```mermaid
+%%{init: { 'theme': 'default' } }%%
+flowchart TD
+    vendors[vendors.txt]
+    custom[custom_vendors.json]
+    update(update_vendors.sh)
+    apps[apps.json]
+    submods[vendor/ submodules]
+    workflow[update-vendors.yml]
+    vendors --> update
+    custom --> update
+    update --> apps
+    update --> submods
+    apps --> workflow
+```

--- a/doc/vendor_update_flow.mmd
+++ b/doc/vendor_update_flow.mmd
@@ -1,0 +1,12 @@
+flowchart TD
+    vendors[vendors.txt]
+    custom[custom_vendors.json]
+    update(update_vendors.sh)
+    apps[apps.json]
+    submods[vendor/ submodules]
+    workflow[update-vendors.yml]
+    vendors --> update
+    custom --> update
+    update --> apps
+    update --> submods
+    apps --> workflow


### PR DESCRIPTION
## Summary
- document helper scripts in vendor guide
- include a mermaid diagram for the vendor workflow
- add release process doc and reference it
- link vendor docs from setup guide
- standardize mermaid instructions in AGENTS
- document mermaid rules in README

## Testing
- `pytest -q` *(fails: test_setup_script_uses_bench_new_app)*

------
https://chatgpt.com/codex/tasks/task_b_6867588902f8832a81cdf505c2590371