### PR TITLE
feat: update setup to run vendor sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The script will:
 - copy required template files into the root of your new app (e.g. `README.md`, `.github/`, `AGENTS.md`, `instructions/`, `scripts/` etc.)
 - create new remote repo <path from .pre-commit-config.yaml>/my_app (is prompted interactively)
 - prepare for GitHub push to your private repository (e.g. `github.com/mygithubacc/frappe-apps/`my_app (you will be prompted interactively)<-- from git hook definitions)
+- run `./scripts/update_vendors.sh` once to fetch vendor submodules before the initial push
 - pushes new generated app repo to remote develop branch
 
 ### GitHub Configuration


### PR DESCRIPTION
## Summary
- run `update_vendors.sh` from `setup.sh` before pushing
- place `.env` in bench root and create it after app creation
- document vendor sync in README
- test that `setup.sh` calls the vendor update script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68675f357e54832ab995d94d182a98bd