### PR TITLE
Update env setup logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,20 @@ The script will:
 - prepare for GitHub push to your private repository (e.g. `github.com/mygithubacc/frappe-apps/`my_app (you will be prompted interactively)<-- from git hook definitions)
 - the GitHub repository is automatically named after your app
 - the GitHub API token is stored in `~/frappe-bench/.env` for reuse
+- app specific values such as the generated SSH key are saved in `apps/my_app/.env`
 - run `./scripts/update_vendors.sh` once to fetch vendor submodules before the initial push
 - pushes new generated app repo to remote develop branch
 
 ### GitHub Configuration
 
-Important credentials, patterns and GitHub tokens should be stored in:
+General GitHub credentials such as the API token and default repo path belong in:
 
 ```bash
 frappe-bench/.env
 ```
 
-> This file is ignored by git and allows central control of all secrets and GitHub-specific parameters.
+Each created app also has its own `.env` which stores repo specific settings like `SSH_KEY_PATH`.
+Both files are ignored by git so secrets remain local.
 
 ### Project Structure
 
@@ -53,7 +55,7 @@ See [doc/trees/app_structure_main.md](doc/trees/app_structure_main.md) for an ex
 Each vendor used by your app has a dedicated folder under `instructions/vendor_profiles/<category>/<slug>/`.
 The folder contains an `apps.json` file with repository information and an optional `AGENTS.md` for vendor‑specific notes.
 
-Run `./scripts/update_vendors.sh` to sync vendors. The script reads `vendors.txt` and `custom_vendors.json`, looks up the matching profiles and adds each repository as a submodule under `vendor/`. If a vendor repository is private, provide a `GITHUB_TOKEN` or `API_KEY` in `.env` or `.config/github_api.json` so the script can clone it. Submodules that no longer appear in the lists are removed and `apps.json` is rewritten with the current metadata.
+Run `./scripts/update_vendors.sh` to sync vendors. The script reads `vendors.txt` and `custom_vendors.json`, looks up the matching profiles and adds each repository as a submodule under `vendor/`. If a vendor repository is private, provide a `GITHUB_TOKEN` or `API_KEY` via the bench `.env`, the repo `.env` or `.config/github_api.json` so the script can clone it. Submodules that no longer appear in the lists are removed and `apps.json` is rewritten with the current metadata.
 
 The `update-vendors.yml` workflow launches this script automatically whenever `vendors.txt` or `custom_vendors.json` change.
 

--- a/doc/scripts/setup_sh.md
+++ b/doc/scripts/setup_sh.md
@@ -20,15 +20,16 @@
 - Wenn **nicht vorhanden**:
   - `bench new-app` wird mit vorgegebenen Werten ausgeführt
   - App-Struktur wird angelegt
-- Erstellt `.env` im Bench-Hauptordner (falls nicht vorhanden)
-- Liest / schreibt Werte wie `API_KEY`, `GITHUB_USER`, `REPO_NAME`, `REPO_PATH`
+  - Erstellt `.env` im Bench-Hauptordner (falls nicht vorhanden) für globale Git-Einstellungen
+  - Legt eine `.env` im App-Ordner an und speichert dort `REPO_NAME`, `REPO_PATH` und `SSH_KEY_PATH`
+  - Liest bzw. schreibt `API_KEY` und `GITHUB_USER` ausschließlich im Bench-`.env`
 
 ---
 
 ## 🔐 SSH-Zugang
 - Generiert SSH-Key `~/.ssh/id_deploy_<repo>` (falls nicht vorhanden)
 - Fügt Eintrag zu `~/.ssh/config` hinzu mit Host-Alias `github.com-<repo>`
-- Schreibt `SSH_KEY_PATH` in `.env`
+ - Schreibt `SSH_KEY_PATH` in die `.env` der App
 
 ---
 
@@ -36,7 +37,7 @@
 - Erstellt GitHub-Repo per API (entweder user- oder org-basiert)
 - Erkennt, ob Repo schon existiert und fragt ggf. nach Push
 - Optional: Hängt Deploy-Key ans GitHub-Repo (wenn nicht bereits vorhanden)
-- Speichert `DEPLOY_KEY_ADDED` in `.env`
+ - Speichert `DEPLOY_KEY_ADDED` in der app-spezifischen `.env`
 
 ---
 

--- a/doc/scripts/vendor_management.md
+++ b/doc/scripts/vendor_management.md
@@ -10,7 +10,7 @@ This document explains how vendor repositories are integrated into your app via 
 
 ## Script: `update_vendors.sh`
 
-The script reads both `vendors.txt` and `custom_vendors.json`, resolves the repository URL and ref from the vendor profiles and clones every entry as a submodule under the `vendor/` directory. When a vendor repository is private, provide a `GITHUB_TOKEN` or `API_KEY` via `.env` or `.config/github_api.json` so the script can authenticate.
+The script reads both `vendors.txt` and `custom_vendors.json`, resolves the repository URL and ref from the vendor profiles and clones every entry as a submodule under the `vendor/` directory. When a vendor repository is private, provide a `GITHUB_TOKEN` or `API_KEY` via the bench `.env` or the repo's `.env`, or `.config/github_api.json` so the script can authenticate.
 
 Submodules removed from the lists are deleted, and the updated state is written back to `apps.json`.
 

--- a/scripts/update_vendors.sh
+++ b/scripts/update_vendors.sh
@@ -14,12 +14,19 @@ VENDOR_DIR="$ROOT_DIR/vendor"
 VENDORS_FILE="${VENDORS_FILE:-$ROOT_DIR/vendors.txt}"
 PROFILES_DIR="${PROFILES_DIR:-$ROOT_DIR/instructions/vendor_profiles}"
 
-# load API key from .env if present
+# load API key from .env files if present
 ENV_FILE="$ROOT_DIR/.env"
+BENCH_ENV_FILE="$(dirname "$ROOT_DIR")/.env"
+if [ ! -f "$BENCH_ENV_FILE" ] && [ -f "$(dirname "$ROOT_DIR")/../.env" ]; then
+  BENCH_ENV_FILE="$(dirname "$ROOT_DIR")/../.env"
+fi
 CONFIG_FILE="$ROOT_DIR/.config/github_api.json"
 API_KEY="${API_KEY:-}"
 if [ -z "$API_KEY" ] && [ -f "$ENV_FILE" ]; then
   API_KEY=$(grep -E '^API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)
+fi
+if [ -z "$API_KEY" ] && [ -f "$BENCH_ENV_FILE" ]; then
+  API_KEY=$(grep -E '^API_KEY=' "$BENCH_ENV_FILE" | cut -d'=' -f2-)
 fi
 if [ -z "$API_KEY" ] && [ -f "$CONFIG_FILE" ]; then
   API_KEY=$(jq -r '.API_KEY // .GITHUB_TOKEN // empty' "$CONFIG_FILE" 2>/dev/null)

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -55,11 +55,15 @@ fi
     assert (root / "license.txt").exists()
     assert (root / ".gitignore").exists()
     assert (app_path / "patches.txt").exists()
-    env_file = tmp_path / ".env"
-    assert env_file.exists()
-    text = env_file.read_text()
-    assert "API_KEY=dummyapikeydummyapikey" in text
-    assert "REPO_NAME=demoapp" in text
+    bench_env = tmp_path / ".env"
+    assert bench_env.exists()
+    bench_text = bench_env.read_text()
+    assert "API_KEY=dummyapikeydummyapikey" in bench_text
+    assert "REPO_NAME" not in bench_text
+    app_env = app_path / ".env"
+    assert app_env.exists()
+    app_text = app_env.read_text()
+    assert "REPO_NAME=demoapp" in app_text
 
 
 def test_setup_script_runs_update_vendors(tmp_path):
@@ -137,9 +141,11 @@ fi
     env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
     subprocess.run([str(tmp_script), "demo2"], cwd=tmp_path, check=True, env=env)
 
-    text = (tmp_path / ".env").read_text()
-    assert "API_KEY=stored" in text
-    assert "REPO_NAME=demo2" in text
+    bench_text = (tmp_path / ".env").read_text()
+    assert "API_KEY=stored" in bench_text
+    assert "REPO_NAME" not in bench_text
+    app_text = (tmp_path / "apps" / "demo2" / ".env").read_text()
+    assert "REPO_NAME=demo2" in app_text
 
 
 def test_setup_script_fails_if_app_exists(tmp_path):


### PR DESCRIPTION
## Summary
- split env handling between bench and per-app config
- document env file usage in README and docs
- adapt vendor update script to read bench and local env files
- update tests for new env layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6867db65384c832aaf801b4208a736c9