### PR TITLE
Add verbose logging for new app env file

### DIFF
--- a/doc/scripts/setup_sh.md
+++ b/doc/scripts/setup_sh.md
@@ -21,7 +21,8 @@
   - `bench new-app` wird mit vorgegebenen Werten ausgeführt
   - App-Struktur wird angelegt
   - Erstellt `.env` im Bench-Hauptordner (falls nicht vorhanden) für globale Git-Einstellungen
-  - Legt eine `.env` im App-Ordner an und speichert dort `REPO_NAME`, `REPO_PATH` und `SSH_KEY_PATH`
+- Legt eine `.env` im App-Ordner an und speichert dort `REPO_NAME`, `REPO_PATH` und `SSH_KEY_PATH`
+  - Gibt bei neu angelegter Datei im `--verbose`-Modus den Pfad mit `vlog` aus
   - Liest bzw. schreibt `API_KEY` und `GITHUB_USER` ausschließlich im Bench-`.env`
 
 ---

--- a/setup.sh
+++ b/setup.sh
@@ -136,7 +136,10 @@ mkdir -p "$CONFIG_TARGET"
 [ -f "$BENCH_ENV_FILE" ] || touch "$BENCH_ENV_FILE"
 chmod 600 "$BENCH_ENV_FILE"
 APP_ENV_FILE="$CONFIG_TARGET/.env"
-[ -f "$APP_ENV_FILE" ] || touch "$APP_ENV_FILE"
+if [ ! -f "$APP_ENV_FILE" ]; then
+  touch "$APP_ENV_FILE"
+  vlog "Created app env file at $APP_ENV_FILE"
+fi
 chmod 600 "$APP_ENV_FILE"
 
 migrate_repo_env_values


### PR DESCRIPTION
## Summary
- log creation of new app env file in `setup.sh` when `--verbose`
- document the new verbose log behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68681417f464832a858b6d6a85b90977