### PR TITLE
Improve vendor update messages

### DIFF
--- a/scripts/update_vendors.sh
+++ b/scripts/update_vendors.sh
@@ -60,7 +60,14 @@ mkdir -p "$VENDOR_DIR"
 cd "$ROOT_DIR"
 
 # read vendors list
-readarray -t RAW_LINES < <(grep -v '^#' "$VENDORS_FILE" 2>/dev/null | sed '/^\s*$/d')
+if [ ! -f "$VENDORS_FILE" ]; then
+  echo "⚠️  $VENDORS_FILE not found. Skipping vendor update." >&2
+  exit 0
+fi
+readarray -t RAW_LINES < <(grep -v '^#' "$VENDORS_FILE" | sed '/^\s*$/d')
+if [ ${#RAW_LINES[@]} -eq 0 ]; then
+  echo "ℹ️  No active vendors listed in $VENDORS_FILE"
+fi
 
 # integration data
 declare -A REPOS

--- a/setup.sh
+++ b/setup.sh
@@ -388,7 +388,11 @@ fi
 # run vendor update before optional initial push
 if [ -x "./scripts/update_vendors.sh" ]; then
   log "Running update_vendors.sh to fetch vendor apps..."
-  ./scripts/update_vendors.sh
+  if ./scripts/update_vendors.sh; then
+    log "Vendor update finished."
+  else
+    log "update_vendors.sh failed – continuing without vendor changes"
+  fi
   git add .gitmodules apps.json vendors.txt 2>/dev/null || true
   if [ -d vendor ]; then
     git add vendor


### PR DESCRIPTION
## Summary
- improve error handling in `update_vendors.sh`
- don't abort setup if vendor update fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68690bc0dd00832a9f766a04accc41c9