### PR TITLE
Improve vendor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See [doc/trees/app_structure_main.md](doc/trees/app_structure_main.md) for an ex
 Each vendor used by your app has a dedicated folder under `instructions/vendor_profiles/<category>/<slug>/`.
 The folder contains an `apps.json` file with repository information and an optional `AGENTS.md` for vendor‑specific notes.
 
-Run `./scripts/update_vendors.sh` to sync vendors. The script reads `vendors.txt` and `custom_vendors.json`, looks up the matching profiles and adds each repository as a submodule under `vendor/`. If a vendor repository is private, provide a `GITHUB_TOKEN` or `API_KEY` via the bench `.env`, the repo `.env` or `.config/github_api.json` so the script can clone it. The script relies on `jq` for JSON parsing, so make sure `jq` is installed. Submodules that no longer appear in the lists are removed and `apps.json` is rewritten with the current metadata. Use `--verbose` to print detailed progress.
+Run `./scripts/update_vendors.sh` to sync vendors. The script reads `vendors.txt` and `custom_vendors.json`, looks up the matching profiles and adds each repository as a submodule under `vendor/`. When a vendor repository is private, the script first tries your global GitHub token from the bench `.env` or `.config/github_api.json`. If cloning fails, it will ask you to enter a token interactively. The script relies on `jq` for JSON parsing. Submodules that no longer appear in the lists are removed and `apps.json` is rewritten with the current metadata. Use `--verbose` to print detailed progress.
 
 The `update-vendors.yml` workflow launches this script automatically whenever `vendors.txt` or `custom_vendors.json` change.
 

--- a/doc/scripts/vendor_management.md
+++ b/doc/scripts/vendor_management.md
@@ -10,7 +10,7 @@ This document explains how vendor repositories are integrated into your app via 
 
 ## Script: `update_vendors.sh`
 
-The script reads both `vendors.txt` and `custom_vendors.json`, resolves the repository URL and ref from the vendor profiles and clones every entry as a submodule under the `vendor/` directory. When a vendor repository is private, provide a `GITHUB_TOKEN` or `API_KEY` via the bench `.env` or the repo's `.env`, or `.config/github_api.json` so the script can authenticate. `update_vendors.sh` depends on `jq` for parsing JSON, so ensure it is installed before running the script.
+The script reads both `vendors.txt` and `custom_vendors.json`, resolves the repository URL and ref from the vendor profiles and clones every entry as a submodule under the `vendor/` directory. If a vendor repository is private, `update_vendors.sh` tries the GitHub token from the bench `.env` or `.config/github_api.json`. Should cloning fail, the script prompts you for a token on the command line. `update_vendors.sh` depends on `jq` for parsing JSON, so ensure it is installed before running the script.
 
 Submodules removed from the lists are deleted, and the updated state is written back to `apps.json`.
 


### PR DESCRIPTION
## Summary
- handle missing API_KEY gracefully in update_vendors.sh
- allow interactive fallback for cloning private vendors
- document new private vendor behavior in README and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68691c6bf818832a90a7480cf66fb529