### PR TITLE
Update vendor instructions sync

### DIFF
--- a/doc/scripts/update_vendors.md
+++ b/doc/scripts/update_vendors.md
@@ -1,6 +1,6 @@
 # update_vendors.sh
 
-Synchronise vendor submodules based on `vendors.txt` and `custom_vendors.json`. The script requires `jq` for JSON handling. Active vendor profiles are copied into `instructions/vendor_profiles/<relpath>` automatically. See [vendor_management.md](vendor_management.md) for details.
+Synchronise vendor submodules based on `vendors.txt` and `custom_vendors.json`. The script requires `jq` for JSON handling. Active vendor profiles are copied into `instructions/vendor_profiles/<relpath>` automatically and mirrored to `instructions/<slug>`. See [vendor_management.md](vendor_management.md) for details.
 
 ```mermaid
 flowchart TD

--- a/doc/scripts/vendor_management.md
+++ b/doc/scripts/vendor_management.md
@@ -18,6 +18,8 @@ Whenever a vendor profile is used, its directory is copied into
 `instructions/vendor_profiles/<relpath>` so the repository keeps the exact profile
 that resolved the vendor entry. The copy is skipped if the destination already
 matches the source.
+The same information is also synced to `instructions/<slug>` so vendor specific
+instructions are easily accessible without the profile hierarchy.
 
 ## Other helper scripts
 

--- a/scripts/update_vendors.sh
+++ b/scripts/update_vendors.sh
@@ -213,15 +213,6 @@ recognized=("${!KEEP[@]}")
 changes=false
 
 mkdir -p "$ROOT_DIR/instructions/vendor_profiles"
-for slug in "${recognized[@]}"; do
-  profile_dir="${PROFILE_DIRS[$slug]:-}"
-  if [[ -n "$profile_dir" && -d "$profile_dir" ]]; then
-    rel_dir="${profile_dir#"$PROFILES_DIR"/}"
-    dest_dir="$ROOT_DIR/instructions/vendor_profiles/$rel_dir"
-    mkdir -p "$dest_dir"
-    rsync -a "$profile_dir/" "$dest_dir/"
-  fi
-done
 
   for slug in "${recognized[@]}"; do
     repo="${REPOS[$slug]}"
@@ -369,6 +360,12 @@ done
     if ! [ -d "$dest" ] || ! diff -qr "$src" "$dest" >/dev/null 2>&1; then
       mkdir -p "$dest"
       rsync -a --delete "$src/" "$dest/"
+    fi
+    # also copy vendor instructions to top-level instructions/<slug>
+    if [ -d "$src" ]; then
+      top_dest="$ROOT_DIR/instructions/$slug"
+      mkdir -p "$top_dest"
+      rsync -a --delete "$src/" "$top_dest/"
     fi
   fi
 done


### PR DESCRIPTION
## Summary
- copy vendor instructions from template into the main instructions folder
- document vendor instruction sync in docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686927d31238832ab026272198c9511e