### PR TITLE
Fix vendor instruction copy logic

### DIFF
--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -214,7 +214,11 @@ def test_setup_script_fails_if_app_exists(tmp_path):
 
 
 def test_setup_script_copies_template_instructions(tmp_path):
-
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "setup.sh"
+    tmp_script = tmp_path / "setup.sh"
+    tmp_script.write_text(script_path.read_text())
+    tmp_script.chmod(0o755)
 
     # replace submodule URL with local path to include template files
     data = tmp_script.read_text().replace(


### PR DESCRIPTION
## Summary
- copy vendor profile instructions only for slugs listed in `vendors.txt`
- initialize variables in setup script test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6869346980e0832abc8994da9504d3d1