### PR TITLE
Remove inaccessible vendor submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,3 @@
-[submodule "vendor/frappe"]
-	path = vendor/frappe
-	url = https://github.com/frappe/frappe
-[submodule "vendor/bench"]
-	path = vendor/bench
-	url = https://github.com/frappe/bench
-[submodule "vendor/nmb_tools-develop"]
-	path = vendor/nmb_tools-develop
-	url = https://github.com/Freddyslim/nmb_tools
 [submodule "vendor/frappe-version-15"]
 	path = vendor/frappe-version-15
 	url = https://github.com/frappe/frappe


### PR DESCRIPTION
## Summary
- drop the `nmb_tools-develop` submodule causing CI checkout failures
- clean up `.gitmodules`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68693e6809f0832a9b14e960e41e0959