### PR TITLE
docs: switch vendor workflow to clone repos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,9 @@ The `How to Code` section in `README.md` will be automatically updated and list 
 
 ### Vendor-Specific Agent Profiles
 
-If submodules or vendor folders exist under `/vendors` in the repository, then:
+If vendor repositories exist under `/vendor` in the repository, then:
 
-- Look for a vendor-specific agent profile in `instructions/<vendorname>/AGENTS.md` – **but only if `<vendorname>` is actually included as a folder or submodule under `/vendors/`**
+- Look for a vendor-specific agent profile in `instructions/<vendorname>/AGENTS.md` – **but only if `<vendorname>` is actually included as a folder under `/vendor/`**
 - **If such an `AGENTS.md` exists**, it takes precedence over conflicting instructions in the main `AGENTS.md`
 
 ---

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The script will:
 - the GitHub repository is automatically named after your app
 - the GitHub API token is stored in `~/frappe-bench/.env` for reuse
 - repo specific values like `REPO_NAME`, `REPO_PATH`, `SSH_KEY_PATH` and `DEPLOY_KEY_ADDED` are stored in `apps/my_app/.env`; keys from the bench `.env` are moved here if found
-- run `./scripts/update_vendors.sh` to fetch vendor submodules before the initial push
+- run `./scripts/update_vendors.sh` to fetch vendor repositories before the initial push
   (use `--verbose` to see detailed logs)
 - push the new repository to the remote `develop` branch
 
@@ -58,7 +58,7 @@ See [doc/trees/app_structure_main.md](doc/trees/app_structure_main.md) for an ex
 Vendor profile templates live under `frappe_app_template/instructions/vendor_profiles/<category>/<slug>/`.
 Each profile contains an `apps.json` file with repository information and an optional `AGENTS.md` for vendor-specific notes. When `update_vendors.sh` runs, the instructions for active vendors are copied to `instructions/<slug>` in your app.
 
-Run `./scripts/update_vendors.sh` to sync vendors. The script reads `vendors.txt` and `custom_vendors.json`, looks up the matching profiles and adds each repository as a submodule under `vendor/`. When a vendor repository is private, the script first tries your global GitHub token from the bench `.env` or `.config/github_api.json`. If cloning fails, it will ask you to enter a token interactively. The script relies on `jq` for JSON parsing. Submodules that no longer appear in the lists are removed and `apps.json` is rewritten with the current metadata. Use `--verbose` to print detailed progress.
+Run `./scripts/update_vendors.sh` to sync vendors. The script reads `vendors.txt` and `custom_vendors.json`, looks up the matching profiles and clones each repository directly under `vendor/`. When a vendor repository is private, the script first tries your global GitHub token from the bench `.env` or `.config/github_api.json`. If cloning fails, it will ask you to enter a token interactively. The script relies on `jq` for JSON parsing. Vendor directories that no longer appear in the lists are removed and `apps.json` is rewritten with the current metadata. Use `--verbose` to print detailed progress.
 
 The `update-vendors.yml` workflow launches this script automatically whenever `vendors.txt` or `custom_vendors.json` change.
 
@@ -84,7 +84,7 @@ All hook definitions live in `.pre-commit-config.yaml` at the repository root.
 This template comes with GitHub Actions workflows for:
 
 - CI testing
-- automated vendor submodule updates via `update-vendors.yml`
+- automated vendor repository updates via `update-vendors.yml`
 - commit linting and validation
 
 Workflow examples are stored in `workflow_templates/`. Copy them into

--- a/doc/scripts/clone_submodules.md
+++ b/doc/scripts/clone_submodules.md
@@ -1,6 +1,6 @@
 # clone_submodules.sh
 
-This script clones all vendor submodules listed in `vendors.txt` or a custom template file. Each repository is checked out at the specified branch or tag. Any `instructions` folders from the vendors are copied into `instructions/_<name>/`.
+This script clones all vendor repositories listed in `vendors.txt` or a custom template file. Each repository is checked out at the specified branch or tag. Any `instructions` folders from the vendors are copied into `instructions/_<name>/`.
 
 ```mermaid
 flowchart TD

--- a/doc/scripts/remove_submodule.md
+++ b/doc/scripts/remove_submodule.md
@@ -1,6 +1,6 @@
 # remove_submodule.sh
 
-Safely remove a vendor submodule and its instructions directory.
+Safely remove a vendor repository directory and its instructions.
 
 ```mermaid
 flowchart TD

--- a/doc/scripts/update_vendors.md
+++ b/doc/scripts/update_vendors.md
@@ -1,6 +1,6 @@
 # update_vendors.sh
 
-Synchronise vendor submodules based on `vendors.txt` and `custom_vendors.json`. The script requires `jq` for JSON handling. Instruction folders for active vendors are mirrored to `instructions/<slug>`. See [vendor_management.md](vendor_management.md) for details.
+Synchronise vendor repositories based on `vendors.txt` and `custom_vendors.json`. The script requires `jq` for JSON handling. Instruction folders for active vendors are mirrored to `instructions/<slug>`. See [vendor_management.md](vendor_management.md) for details.
 
 ```mermaid
 flowchart TD

--- a/doc/scripts/vendor_management.md
+++ b/doc/scripts/vendor_management.md
@@ -1,6 +1,6 @@
 # Vendor Management
 
-This document explains how vendor repositories are integrated into your app via submodules.
+This document explains how vendor repositories are integrated into your app without using git submodules.
 
 ## Files
 
@@ -10,9 +10,9 @@ This document explains how vendor repositories are integrated into your app via 
 
 ## Script: `update_vendors.sh`
 
-The script reads both `vendors.txt` and `custom_vendors.json`, resolves the repository URL and ref from the vendor profiles and clones every entry as a submodule under the `vendor/` directory. If a vendor repository is private, `update_vendors.sh` tries the GitHub token from the bench `.env` or `.config/github_api.json`. Should cloning fail, the script prompts you for a token on the command line. `update_vendors.sh` depends on `jq` for parsing JSON, so ensure it is installed before running the script.
+The script reads both `vendors.txt` and `custom_vendors.json`, resolves the repository URL and ref from the vendor profiles and clones every entry directly under the `vendor/` directory. If a vendor repository is private, `update_vendors.sh` tries the GitHub token from the bench `.env` or `.config/github_api.json`. Should cloning fail, the script prompts you for a token on the command line. `update_vendors.sh` depends on `jq` for parsing JSON, so ensure it is installed before running the script.
 
-Submodules removed from the lists are deleted, and the updated state is written back to `apps.json`.
+Vendor directories removed from the lists are deleted, and the updated state is written back to `apps.json`.
 
 Whenever a vendor is processed, its instruction directory from the profile is
 mirrored to `instructions/<slug>` in your app. The `vendor_profiles` directory
@@ -20,14 +20,14 @@ is not copied into the project.
 
 ## Other helper scripts
 
-- `clone_submodules.sh` – clones vendor submodules listed in `vendors.txt` without updating existing entries.
-- `remove_submodule.sh` – removes a specific vendor submodule and its instructions directory.
+- `clone_submodules.sh` – clones vendor repositories listed in `vendors.txt` without updating existing entries.
+- `remove_submodule.sh` – removes a specific vendor repository directory and its instructions.
 
 Both scripts live in the `scripts/` folder and are useful for manual vendor maintenance.
 
 ## GitHub Workflow
 
-`update-vendors.yml` triggers `update_vendors.sh` automatically whenever `vendors.txt` or `custom_vendors.json` change. The workflow commits updated submodules and documentation back to the repository.
+`update-vendors.yml` triggers `update_vendors.sh` automatically whenever `vendors.txt` or `custom_vendors.json` change. The workflow commits updated vendor directories and documentation back to the repository.
 
 ## Diagram
 
@@ -40,7 +40,7 @@ flowchart TD
     custom[custom_vendors.json]
     update(update_vendors.sh)
     apps[apps.json]
-    submods[vendor/ submodules]
+    submods[vendor/ repositories]
     workflow[update-vendors.yml]
     vendors --> update
     custom --> update

--- a/doc/scripts/vendor_update_flow.mmd
+++ b/doc/scripts/vendor_update_flow.mmd
@@ -3,7 +3,7 @@ flowchart TD
     custom[custom_vendors.json]
     update(update_vendors.sh)
     apps[apps.json]
-    submods[vendor/ submodules]
+    submods[vendor/ repositories]
     workflow[update-vendors.yml]
     vendors --> update
     custom --> update

--- a/doc/trees/app_structure_develop.md
+++ b/doc/trees/app_structure_develop.md
@@ -19,16 +19,16 @@
         ├── doc/                             # technische Dokumentation (Markdown, Mermaid)
         ├── sample_data/                     # leerer Ordner für optionale Testdaten
         ├── scripts/                         # Hilfsskripte
-        │   ├── clone_submodules.sh          # lädt vendor-Submodule aus vendors.txt/custom_vendors.json
-        │   ├── remove_submodule.sh          # entfernt sauber ein Vendor-Submodul und aktualisiert apps.json
+        │   ├── clone_submodules.sh          # lädt Vendor-Repositories aus vendors.txt/custom_vendors.json
+        │   ├── remove_submodule.sh          # entfernt sauber ein Vendor-Verzeichnis und aktualisiert apps.json
         │   ├── generate_diagrams.sh         # rendert Mermaid-Diagramme aus /doc/
-        │   ├── update_vendors.sh            # synchronisiert Vendor-Submodule (zentraler Einstieg)
+        │   ├── update_vendors.sh            # synchronisiert Vendor-Repositories (zentraler Einstieg)
         │   └── publish_app.sh               # erstellt Release, Tag, PR (manuell oder CI-unterstützt)
         ├── .pre-commit-config.yaml          # Hook-Setup für git (Black, isort, etc.)
         ├── .github/
         │   └── workflows/                   # GitHub Actions CI/CD
         │       ├── ci.yml                   # CI-Tests (z. B. Bench Build)
-        │       ├── update-vendors.yml       # prüft und aktualisiert Vendor-Submodule automatisch
+        │       ├── update-vendors.yml       # prüft und aktualisiert Vendor-Repositories automatisch
         │       └── validate_commits.yml     # prüft Conventional Commit Messages
         ├── .config/
         │   └── github_api.json              # Lokale API Keys / Tokens (nicht versioniert)

--- a/doc/trees/template_structure.md
+++ b/doc/trees/template_structure.md
@@ -4,7 +4,7 @@
 /home/frappe/frappe-bench/
 └── frappe_app_tamplate/
         ├── instructions/                  # app instructions
-        ├── vendor/                        # vendor submodules
+        ├── vendor/                        # vendor repositories
         │   ├── erpnext/
         │   └── nextcloud/
         ├── doc/                           # technical documentation
@@ -16,9 +16,9 @@
         ├── sample_data/                   # empty folder reserved for sample datasets
         ├── scripts/
         │   ├── clone_submodules.sh        # pull vendor profiles
-        │   ├── remove_submodule.sh        # remove unwanted vendor
+        │   ├── remove_submodule.sh        # remove unwanted vendor directory
         │   ├── generate_diagrams.sh       # render Mermaid diagrams from doc/
-        │   ├── update_vendors.sh          # sync vendor submodules
+        │   ├── update_vendors.sh          # sync vendor repositories
         │   └── publish_app.sh             # manual publish app without dev files --> create pull request with new tag <vx.x.x> auto upscaling with choice of dev-stable <vx.x.x+1>, test-stable <vx+1.0>, major <vx+1.0.0>
         │                                  # run with -h to see options
 

--- a/doc/workflow_templates.md
+++ b/doc/workflow_templates.md
@@ -5,6 +5,6 @@ This repository provides minimal GitHub Actions workflows that you can reuse in 
 - **`ci.yml`** – installs Python dependencies and acts as a starting point for custom CI steps. Extend it with linting or packaging commands as needed.
 - **`generate-mermaid.yml`** – rebuilds diagrams from `.mmd` files in `doc/` and pushes the resulting `.svg` files back to the repository.
 - **`test.yml`** – runs unit tests using `pytest` and performs a simple ShellCheck on scripts.
-- **`update-vendors.yml`** – watches `vendors.txt` and `custom_vendors.json`. When either file changes the workflow runs `scripts/update_vendors.sh` to clone or update the vendor submodules. Removed entries are pruned and `apps.json` is regenerated. The workflow uses the repository `GITHUB_TOKEN` so private vendor repositories can be pulled as well.
+- **`update-vendors.yml`** – watches `vendors.txt` and `custom_vendors.json`. When either file changes the workflow runs `scripts/update_vendors.sh` to clone or update the vendor repositories. Removed entries are pruned and `apps.json` is regenerated. The workflow uses the repository `GITHUB_TOKEN` so private vendor repositories can be pulled as well.
 
 Copy any of these files to `.github/workflows/` in your app repository. The `setup.sh` script does this automatically when you bootstrap a new app, but you can also copy them manually and adjust branches or Python versions to your needs.

--- a/doc/workflows/update_vendors.md
+++ b/doc/workflows/update_vendors.md
@@ -1,6 +1,6 @@
 # update-vendors.yml
 
-Watches `vendors.txt` and `custom_vendors.json` to keep vendor submodules in sync.
+Watches `vendors.txt` and `custom_vendors.json` to keep vendor repositories in sync.
 
 ```mermaid
 flowchart TD

--- a/scripts/remove_submodule.sh
+++ b/scripts/remove_submodule.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# remove_submodule.sh: delete a vendor submodule and its instructions
+# remove_submodule.sh: delete a vendor repository directory and its instructions
 set -euo pipefail
 
 # Prevent execution inside the frappe_app_template submodule

--- a/workflow_templates/update-vendors.yml
+++ b/workflow_templates/update-vendors.yml
@@ -1,4 +1,4 @@
-# Triggers vendor submodule updates when vendors.txt or custom profiles change
+# Triggers vendor repository updates when vendors.txt or custom profiles change
 name: update-vendors
 
 on:


### PR DESCRIPTION
## Summary
- clarify vendor handling in `AGENTS.md`
- update README with new vendor clone workflow
- adjust docs for cloning vendor repositories instead of submodules
- tweak supporting scripts and workflow comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686be9857ad0832ab615c72726d0e693