### PR TITLE
Fix typo in template_structure doc

### DIFF
--- a/doc/trees/template_structure.md
+++ b/doc/trees/template_structure.md
@@ -2,7 +2,7 @@
 
 ```bash
 /home/frappe/frappe-bench/
-└── frappe_app_tamplate/
+└── frappe_app_template/
         ├── instructions/                  # app instructions
         ├── vendor/                        # vendor submodules
         │   ├── erpnext/


### PR DESCRIPTION
## Summary
- correct path typo in template structure documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686c16fb0f6c832ab8a738a294252aac