### PR TITLE
Add non-interactive vendor update script

### DIFF
--- a/.github/workflows/update-vendors.yml
+++ b/.github/workflows/update-vendors.yml
@@ -38,9 +38,11 @@ jobs:
           pip install -r requirements.txt
 
       - name: Update vendors
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "::group::update_vendors"
-          ./scripts/update_vendors.sh | tee /tmp/vendor_summary.txt
+          ./scripts/update_vendors_ci.sh | tee /tmp/vendor_summary.txt
           echo "::endgroup::"
           tail -n 1 /tmp/vendor_summary.txt
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The script will:
 - abort if `apps/my_app/` already exists to avoid overwriting
 - initialize a Git repository in `apps/my_app/`
 - clone the `frappe_app_template` into `apps/my_app/frappe_app_template`
- - copy required template files into the root of your new app (e.g. `README.md`, `.gitignore`, `.github/`, `AGENTS.md`, `PROJEKT.md`, `instructions/` with vendor profiles, `scripts/` etc.)
- - vendor profiles are mirrored under `instructions/<slug>/` so `frappe` and `bench` instructions are ready
+- copy required template files into the root of your new app (e.g. `README.md`, `.gitignore`, `.github/`, `AGENTS.md`, `PROJEKT.md`, `instructions/` with vendor profiles, `scripts/` etc.)
+- vendor profiles are mirrored under `instructions/<slug>/` so `frappe` and `bench` instructions are ready
 - commit all copied files so `git status` is clean even when `bench` created the repo
 - create new remote repo <path from .pre-commit-config.yaml>/my_app (is prompted interactively)
 - prepare for GitHub push to your private repository (e.g. `github.com/mygithubacc/frappe-apps/`my_app (you will be prompted interactively)<-- from git hook definitions)
@@ -52,13 +52,14 @@ Both files are ignored by git so secrets remain local.
 
 The full directory layout is documented in [doc/trees/template_structure.md](doc/trees/template_structure.md).
 
-
 See [doc/trees/app_structure_develop.md](doc/trees/app_structure_develop.md) for the directory created by setup.sh.
 See [doc/trees/app_structure_main.md](doc/trees/app_structure_main.md) for an example layout after release.
 Vendor profile templates live under `frappe_app_template/instructions/vendor_profiles/<category>/<slug>/`.
 Each profile contains an `apps.json` file with repository information and an optional `AGENTS.md` for vendor-specific notes. When `update_vendors.sh` runs, the instructions for active vendors are copied to `instructions/<slug>` in your app.
 
 Run `./scripts/update_vendors.sh` to sync vendors. The script reads `vendors.txt` and `custom_vendors.json`, looks up the matching profiles and clones each repository directly under `vendor/`. When a vendor repository is private, the script first tries your global GitHub token from the bench `.env` or `.config/github_api.json`. If cloning fails, it will ask you to enter a token interactively. The script relies on `jq` for JSON parsing. Vendor directories that no longer appear in the lists are removed and `apps.json` is rewritten with the current metadata. Use `--verbose` to print detailed progress.
+
+For automation (e.g. CI or Codex) use `./scripts/update_vendors_ci.sh` which aborts if `GITHUB_TOKEN` is missing and disables git prompts.
 
 The `update-vendors.yml` workflow launches this script automatically whenever `vendors.txt` or `custom_vendors.json` change.
 
@@ -92,9 +93,18 @@ Workflow examples are stored in `workflow_templates/`. Copy them into
 The [workflow_templates.md](doc/workflow_templates.md) document explains what
 each template does. Details about vendor handling are described in
 [vendor_management.md](doc/scripts/vendor_management.md).
+
+### Codex Environment Setup
+
+1. Add a secret named `GITHUB_TOKEN` in your Codex environment so vendor scripts can access private repositories.
+2. Copy `scripts/setup_codex_env.sh` into the environment and run it once to install dependencies and fetch vendor repositories.
+
 ### Command Restrictions
+
 Codex does not execute real shell commands or network operations while processing this repository. Only file creation and modification is performed. Commands like `bench`, `git`, `curl`, `wget`, `npm` and `ssh` must not run. You may place such commands in scripts or CI files, but they remain inactive during updates.
+
 ### License
+
 MIT
 
 ---
@@ -110,6 +120,7 @@ code with prompts and/or flags and/or --go (starts with reading PROJECT.md).
 --- autocreated ---
 
 Codex processes this repository based on the rules in `AGENTS.md`. The following instructions are currently active:
+
 - Flags have highest priority!
 - Always update `README.md` when `AGENTS.md` includes new instructions relevant to later usage.
 

--- a/doc/scripts/setup_codex_env.md
+++ b/doc/scripts/setup_codex_env.md
@@ -1,0 +1,10 @@
+# setup_codex_env.sh
+
+Prepare a Codex execution environment. It installs dependencies, installs pre‑commit hooks and runs `update_vendors_ci.sh`.
+
+```mermaid
+flowchart TD
+    setup(setup_codex_env.sh) --> deps[install requirements]
+    setup --> hooks[pre-commit install]
+    setup --> update[update_vendors_ci.sh]
+```

--- a/doc/scripts/update_vendors_ci.md
+++ b/doc/scripts/update_vendors_ci.md
@@ -1,0 +1,8 @@
+# update_vendors_ci.sh
+
+Non-interactive wrapper for `update_vendors.sh`. It requires `GITHUB_TOKEN` and sets `GIT_TERMINAL_PROMPT=0` so that vendor repositories can be updated automatically.
+
+```mermaid
+flowchart TD
+    ci(update_vendors_ci.sh) --> vendors[update_vendors.sh]
+```

--- a/doc/scripts/vendor_management.md
+++ b/doc/scripts/vendor_management.md
@@ -25,6 +25,10 @@ is not copied into the project.
 
 Both scripts live in the `scripts/` folder and are useful for manual vendor maintenance.
 
+For non‑interactive use in CI pipelines or the Codex environment, use
+`update_vendors_ci.sh`. It wraps `update_vendors.sh`, aborts when
+`GITHUB_TOKEN` is missing and disables git credential prompts.
+
 ## GitHub Workflow
 
 `update-vendors.yml` triggers `update_vendors.sh` automatically whenever `vendors.txt` or `custom_vendors.json` change. The workflow commits updated vendor directories and documentation back to the repository.

--- a/doc/workflows/update_vendors.md
+++ b/doc/workflows/update_vendors.md
@@ -1,10 +1,10 @@
 # update-vendors.yml
 
-Watches `vendors.txt` and `custom_vendors.json` to keep vendor repositories in sync.
+Watches `vendors.txt` and `custom_vendors.json` to keep vendor repositories in sync. It calls `update_vendors_ci.sh` to run the update without prompting for credentials.
 
 ```mermaid
 flowchart TD
     files[vendors.txt & custom_vendors.json] --> workflow(update-vendors.yml)
-    workflow --> script[run update_vendors.sh]
+    workflow --> script[run update_vendors_ci.sh]
     script --> commit[commit changes]
 ```

--- a/scripts/setup_codex_env.sh
+++ b/scripts/setup_codex_env.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# setup_codex_env.sh: prepare Codex environment for this template
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "GITHUB_TOKEN not set. Export it before running." >&2
+  exit 1
+fi
+
+python3 -m pip install --upgrade pip >/dev/null
+pip install -r "$ROOT_DIR/requirements.txt" >/dev/null
+pre-commit install >/dev/null
+
+"$SCRIPT_DIR/update_vendors_ci.sh"

--- a/scripts/update_vendors_ci.sh
+++ b/scripts/update_vendors_ci.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# update_vendors_ci.sh: run update_vendors.sh without any prompts
+set -euo pipefail
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "GITHUB_TOKEN environment variable not set" >&2
+  exit 1
+fi
+
+export GIT_TERMINAL_PROMPT=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/update_vendors.sh" "$@"


### PR DESCRIPTION
## Summary
- add `update_vendors_ci.sh` wrapper
- add Codex environment setup script
- document new scripts and update workflow docs
- mention new automation in README
- run vendor update through new script in workflow

## Testing
- `pytest -q`
- `pre-commit run --files scripts/update_vendors_ci.sh scripts/setup_codex_env.sh README.md doc/scripts/update_vendors_ci.md doc/scripts/setup_codex_env.md doc/scripts/vendor_management.md .github/workflows/update-vendors.yml doc/workflows/update_vendors.md`

------
https://chatgpt.com/codex/tasks/task_b_686c1b452a7c832a9b86e936f57b2bfb