### PR TITLE
Update vendor copy script to read tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Vendor profile templates live under `frappe_app_template/instructions/vendor_pro
 Each profile contains an `apps.json` file with repository information and an optional `AGENTS.md` for vendor-specific notes. When `update_vendors.sh` runs, the instructions for active vendors are copied to `instructions/<slug>` in your app.
 
 Run `./scripts/update_vendors.sh` to sync vendors. The script reads `vendors.txt` and `custom_vendors.json`, looks up the matching profiles and adds each repository as a git submodule under `vendor/`. When a vendor repository is private, the script first tries your global GitHub token from the bench `.env` or `.config/github_api.json`. If cloning fails, it will ask you to enter a token interactively. The script relies on `jq` for JSON parsing. Submodules no longer listed are removed and `apps.json` is rewritten with the current metadata. Use `--verbose` to print detailed progress.
-If you want to avoid submodules completely, run `./scripts/update_vendors_copy.sh` instead. It clones each vendor repository and stores a plain copy under `vendor/`.
+If you want to avoid submodules completely, run `./scripts/update_vendors_copy.sh` instead. It clones each vendor repository and stores a plain copy under `vendor/`. The script uses the same `GITHUB_TOKEN`/`API_KEY` lookup as `update_vendors.sh`.
 
 For automation (e.g. CI or Codex) use `./scripts/update_vendors_ci.sh` which aborts if `GITHUB_TOKEN` is missing and disables git prompts.
 

--- a/doc/scripts/update_vendors_copy.md
+++ b/doc/scripts/update_vendors_copy.md
@@ -1,6 +1,6 @@
 # update_vendors_copy.sh
 
-Variant of `update_vendors.sh` that clones vendor repositories and stores them as normal directories without git metadata. Use this when you prefer not to keep submodules.
+Variant of `update_vendors.sh` that clones vendor repositories and stores them as normal directories without git metadata. Use this when you prefer not to keep submodules. It reads `GITHUB_TOKEN` or `API_KEY` from the project and bench `.env` files (or `.config/github_api.json`) so private repositories can be accessed automatically.
 
 ```mermaid
 flowchart TD

--- a/doc/scripts/vendor_management.md
+++ b/doc/scripts/vendor_management.md
@@ -23,7 +23,7 @@ is not copied into the project.
 
 - `clone_repo.sh` – adds vendor repositories listed in `vendors.txt` as submodules without updating existing entries.
 - `remove_repo.sh` – removes a specific vendor repository directory and its instructions.
-- `update_vendors_copy.sh` – clones vendors as regular directories without keeping the `.git` metadata.
+- `update_vendors_copy.sh` – clones vendors as regular directories without keeping the `.git` metadata. The script uses the same `GITHUB_TOKEN`/`API_KEY` lookup as `update_vendors.sh` so private repositories work out of the box.
 
 Both scripts live in the `scripts/` folder and are useful for manual vendor maintenance.
 

--- a/scripts/update_vendors.sh
+++ b/scripts/update_vendors.sh
@@ -55,6 +55,16 @@ fi
 if [ -z "$API_KEY" ] && [ -f "$CONFIG_FILE" ]; then
   API_KEY=$(jq -r '.API_KEY // .GITHUB_TOKEN // empty' "$CONFIG_FILE" 2>/dev/null)
 fi
+
+if [ -z "${GITHUB_TOKEN:-}" ] && [ -f "$ENV_FILE" ]; then
+  GITHUB_TOKEN=$(grep -E '^GITHUB_TOKEN=' "$ENV_FILE" | cut -d'=' -f2- || true)
+fi
+if [ -z "${GITHUB_TOKEN:-}" ] && [ -f "$BENCH_ENV_FILE" ]; then
+  GITHUB_TOKEN=$(grep -E '^GITHUB_TOKEN=' "$BENCH_ENV_FILE" | cut -d'=' -f2- || true)
+fi
+if [ -z "${GITHUB_TOKEN:-}" ] && [ -f "$CONFIG_FILE" ]; then
+  GITHUB_TOKEN=$(jq -r '.GITHUB_TOKEN // .API_KEY // empty' "$CONFIG_FILE" 2>/dev/null)
+fi
 GITHUB_TOKEN="${GITHUB_TOKEN:-$API_KEY}"
 
 with_auth_repo() {

--- a/scripts/update_vendors_copy.sh
+++ b/scripts/update_vendors_copy.sh
@@ -52,6 +52,16 @@ fi
 if [ -z "$API_KEY" ] && [ -f "$CONFIG_FILE" ]; then
   API_KEY=$(jq -r '.API_KEY // .GITHUB_TOKEN // empty' "$CONFIG_FILE" 2>/dev/null)
 fi
+
+if [ -z "${GITHUB_TOKEN:-}" ] && [ -f "$ENV_FILE" ]; then
+  GITHUB_TOKEN=$(grep -E '^GITHUB_TOKEN=' "$ENV_FILE" | cut -d'=' -f2- || true)
+fi
+if [ -z "${GITHUB_TOKEN:-}" ] && [ -f "$BENCH_ENV_FILE" ]; then
+  GITHUB_TOKEN=$(grep -E '^GITHUB_TOKEN=' "$BENCH_ENV_FILE" | cut -d'=' -f2- || true)
+fi
+if [ -z "${GITHUB_TOKEN:-}" ] && [ -f "$CONFIG_FILE" ]; then
+  GITHUB_TOKEN=$(jq -r '.GITHUB_TOKEN // .API_KEY // empty' "$CONFIG_FILE" 2>/dev/null)
+fi
 GITHUB_TOKEN="${GITHUB_TOKEN:-$API_KEY}"
 
 with_auth_repo() {


### PR DESCRIPTION
## Summary
- handle `GITHUB_TOKEN` from `.env` in `update_vendors.sh` and `update_vendors_copy.sh`
- document token lookup in README and vendor docs

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686e616f693c832abe2c4b8233257500